### PR TITLE
fix(web): unify markdown typography and remove debug telemetry

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -650,10 +650,9 @@ pre, code {
 }
 
 .markdown-reasoning a {
-  color: var(--color-foreground);
+  color: var(--color-focus);
   text-decoration: underline;
-  text-decoration-style: dotted;
-  text-underline-offset: 3px;
+  text-underline-offset: 2px;
 }
 
 .markdown-reasoning.streaming-active:empty::after,

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -369,7 +369,7 @@ body {
 }
 
 /* Design contract:
-   - Panels/surfaces use rounded-lg.
+   - Panels/surfaces use rounded-xl (see docs/reference/design-system.md).
    - Controls (inputs, buttons, badges) use rounded-md.
    - Focus ring uses ring-2/ring-ring/ring-offset-2/ring-offset-background. */
 
@@ -635,7 +635,7 @@ pre, code {
   margin: 0.5em 0;
   background: var(--color-background);
   border: 1px solid var(--color-border);
-  border-radius: 0.375rem;
+  border-radius: var(--radius-lg);
   padding: 0.75em 1em;
 }
 
@@ -645,14 +645,8 @@ pre, code {
 
 .markdown-reasoning :not(pre) > code {
   background: var(--color-muted);
-  border-radius: 0.25rem;
+  border-radius: var(--radius-md);
   padding: 0.15em 0.3em;
-}
-
-.markdown-reasoning a {
-  color: var(--color-focus);
-  text-decoration: underline;
-  text-underline-offset: 2px;
 }
 
 .markdown-reasoning.streaming-active:empty::after,
@@ -662,8 +656,8 @@ pre, code {
   vertical-align: baseline;
   width: 0.5em;
   height: 1em;
-  background-color: var(--color-muted-foreground);
+  background-color: var(--color-ai-glow);
   margin-left: 0.25em;
-  border-radius: 1px;
+  border-radius: var(--radius-sm);
   animation: blink-cursor 1.5s ease-in-out infinite;
 }

--- a/web/src/features/agent-computer/components/ToolOutputRenderer.tsx
+++ b/web/src/features/agent-computer/components/ToolOutputRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback } from "react";
 import {
   Terminal,
   Globe,
@@ -154,27 +154,6 @@ export function ToolOutputRenderer({ output, toolName, success, contentType, con
   const handleToggle = useCallback(() => setExpanded((p) => !p), []);
 
   const displayText = isLong && !expanded ? resolvedOutput.slice(0, COLLAPSE_THRESHOLD) : resolvedOutput;
-  const selectedRenderer =
-    isImage ? "image" :
-    isHtml ? "html" :
-    (category === "search" && toolName === "web_search") ? "web-search" :
-    category === "preview" ? "preview-terminal" :
-    toolName === "shell_exec" ? "shell-terminal" :
-    isCode ? "code-output" :
-    (category === "computer" && (toolName === "computer_action" || toolName === "computer_screenshot")) ? "computer-output" :
-    (category === "browser" && toolName === "browser_use") ? "browser-output" :
-    toolName === "agent_wait" ? "agent-wait" :
-    toolName === "agent_receive" ? "agent-receive" :
-    toolName === "database_query" ? "database-query" :
-    (category === "memory" && (toolName === "memory_search" || toolName === "memory_list")) ? "memory" :
-    success === false ? "error-markdown" :
-    "generic-markdown";
-
-  useEffect(() => {
-    // #region agent log
-    fetch("http://127.0.0.1:7800/ingest/f3cbd1e5-6b99-4559-90b9-9eaeb44e6deb", { method: "POST", headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "157ac9" }, body: JSON.stringify({ sessionId: "157ac9", runId: "initial", hypothesisId: "H4", location: "ToolOutputRenderer.tsx:renderer-selection", message: "Resolved tool output renderer branch", data: { toolName, category, contentType: contentType ?? null, success: success ?? null, selectedRenderer, outputLength: output.length }, timestamp: Date.now() }) }).catch(() => {});
-    // #endregion
-  }, [category, contentType, output.length, selectedRenderer, success, toolName]);
 
   // Image artifact rendering
   if (isImage) {

--- a/web/src/features/agent-computer/lib/format-tools.ts
+++ b/web/src/features/agent-computer/lib/format-tools.ts
@@ -6,7 +6,8 @@
  * - text-micro: badges, counters, metadata chips
  * Keep mono only for IDs/counters/code payloads.
  */
-export const PROSE_CLASSES = "text-sm leading-relaxed text-muted-foreground [&_a]:text-user-accent [&_a]:underline [&_code]:rounded [&_code]:bg-muted [&_code]:px-1 [&_code]:py-0.5 [&_li]:my-0.5 [&_ol]:my-1 [&_ol]:pl-4 [&_p]:my-1 [&_pre]:my-1 [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_ul]:my-1 [&_ul]:pl-4";
+/** Tool / panel markdown: body tone + spacing; links and code use MarkdownRenderer defaults. */
+export const PROSE_CLASSES = "text-sm leading-relaxed text-muted-foreground";
 export const TOOL_OUTPUT_MARKDOWN_CLASSES = "";
 export const OUTPUT_CARD_BASE_CLASSES = "mt-2.5 rounded-md border-l-2 border-l-border-strong bg-muted px-2.5 py-1.5";
 export const OUTPUT_HEADER_ROW_CLASSES = "mb-1.5 flex items-center gap-2";

--- a/web/src/features/agent-computer/lib/format-tools.ts
+++ b/web/src/features/agent-computer/lib/format-tools.ts
@@ -7,7 +7,7 @@
  * Keep mono only for IDs/counters/code payloads.
  */
 /** Tool / panel markdown: body tone + spacing; links and code use MarkdownRenderer defaults. */
-export const PROSE_CLASSES = "text-sm leading-relaxed text-muted-foreground";
+export const PROSE_CLASSES = "text-sm leading-normal text-muted-foreground";
 export const TOOL_OUTPUT_MARKDOWN_CLASSES = "";
 export const OUTPUT_CARD_BASE_CLASSES = "mt-2.5 rounded-md border-l-2 border-l-border-strong bg-muted px-2.5 py-1.5";
 export const OUTPUT_HEADER_ROW_CLASSES = "mb-1.5 flex items-center gap-2";

--- a/web/src/shared/components/MarkdownRenderer.tsx
+++ b/web/src/shared/components/MarkdownRenderer.tsx
@@ -35,12 +35,13 @@ function CopyButton({ text }: { text: string }) {
 
   return (
     <button
+      type="button"
       onClick={handleCopy}
-      className="flex items-center gap-1 hover:text-foreground transition-colors p-1"
+      className="flex items-center gap-1 rounded-md p-1 text-muted-foreground transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
       aria-label="Copy code"
       title="Copy code"
     >
-      {copied ? <Check className="h-3.5 w-3.5 text-green-500" /> : <Copy className="h-3.5 w-3.5" />}
+      {copied ? <Check className="h-3.5 w-3.5 text-accent-emerald" /> : <Copy className="h-3.5 w-3.5" />}
       <span className="sr-only">Copy</span>
     </button>
   );
@@ -61,7 +62,7 @@ const components: Components = {
     const codeString = extractText(children);
 
     return (
-      <div className="relative my-4 rounded-lg border bg-muted/50 overflow-hidden not-prose">
+      <div className="relative my-4 rounded-xl border bg-muted/50 overflow-hidden not-prose">
         <div className="flex items-center justify-between px-4 py-1.5 border-b bg-muted text-sm text-muted-foreground font-mono">
           <span>{language}</span>
           <CopyButton text={codeString} />
@@ -117,7 +118,7 @@ const components: Components = {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-accent-purple underline underline-offset-2 hover:text-accent-purple/80"
+        className="text-focus underline underline-offset-2 hover:text-focus/80"
       >
         {children}
       </a>
@@ -139,7 +140,7 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   return (
     <div
       className={cn(
-        "markdown-body font-sans prose prose-sm dark:prose-invert max-w-none break-words prose-p:leading-relaxed prose-pre:p-0",
+        "markdown-body font-sans prose prose-sm dark:prose-invert max-w-none break-words prose-p:leading-normal prose-pre:p-0",
         "prose-p:text-current prose-headings:text-current prose-li:text-current prose-strong:text-current prose-li:marker:text-current",
         isStreaming && "streaming-active",
         className

--- a/web/src/shared/components/MarkdownRenderer.tsx
+++ b/web/src/shared/components/MarkdownRenderer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { memo, useState, useCallback, useEffect, useRef, isValidElement, type ReactNode } from "react";
+import { memo, useState, useCallback, isValidElement, type ReactNode } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
@@ -117,7 +117,7 @@ const components: Components = {
         href={href}
         target="_blank"
         rel="noopener noreferrer"
-        className="text-primary underline underline-offset-2 hover:text-primary/80"
+        className="text-accent-purple underline underline-offset-2 hover:text-accent-purple/80"
       >
         {children}
       </a>
@@ -136,34 +136,8 @@ export const MarkdownRenderer = memo(function MarkdownRenderer({
   className,
   isStreaming,
 }: MarkdownRendererProps) {
-  const rootRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const root = rootRef.current;
-    if (!root) return;
-    const firstParagraph = root.querySelector("p");
-    const firstPre = root.querySelector("pre");
-    const firstInlineCode = root.querySelector("p code");
-    const firstCodeBlockCode = root.querySelector("pre code");
-    const firstCodeHeader = root.querySelector("div.not-prose > div");
-    const getMetrics = (element: Element | null) => {
-      if (!(element instanceof HTMLElement)) return null;
-      const style = window.getComputedStyle(element);
-      return {
-        className: element.className,
-        fontSize: style.fontSize,
-        lineHeight: style.lineHeight,
-        fontFamily: style.fontFamily,
-      };
-    };
-    // #region agent log
-    fetch("http://127.0.0.1:7800/ingest/f3cbd1e5-6b99-4559-90b9-9eaeb44e6deb", { method: "POST", headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "157ac9" }, body: JSON.stringify({ sessionId: "157ac9", runId: "initial", hypothesisId: "H1", location: "MarkdownRenderer.tsx:render-metrics", message: "Captured markdown typography metrics", data: { rootClassName: root.className, extraClassName: className ?? "", paragraph: getMetrics(firstParagraph), pre: getMetrics(firstPre), inlineCode: getMetrics(firstInlineCode), codeBlockCode: getMetrics(firstCodeBlockCode), codeHeader: getMetrics(firstCodeHeader), isStreaming: Boolean(isStreaming) }, timestamp: Date.now() }) }).catch(() => {});
-    // #endregion
-  }, [className, content, isStreaming]);
-
   return (
     <div
-      ref={rootRef}
       className={cn(
         "markdown-body font-sans prose prose-sm dark:prose-invert max-w-none break-words prose-p:leading-relaxed prose-pre:p-0",
         "prose-p:text-current prose-headings:text-current prose-li:text-current prose-strong:text-current prose-li:marker:text-current",

--- a/web/src/shared/components/ui/code-output.tsx
+++ b/web/src/shared/components/ui/code-output.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useMemo, useEffect, useRef } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { Copy, Check } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { cn } from "@/shared/lib/utils";
@@ -23,7 +23,6 @@ export function CodeOutput({ output, icon: Icon, label, language, className }: C
   const { t } = useTranslation();
   const [expanded, setExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
   const handleToggle = useCallback(() => setExpanded((p) => !p), []);
   const isLong = output.length > COLLAPSE_THRESHOLD;
   const displayText = isLong && !expanded ? output.slice(0, COLLAPSE_THRESHOLD) : output;
@@ -43,29 +42,8 @@ export function CodeOutput({ output, icon: Icon, label, language, className }: C
     return `\`\`\`${lang}\n${displayText}\n\`\`\``;
   }, [language, displayText]);
 
-  useEffect(() => {
-    const root = rootRef.current;
-    if (!root) return;
-    const firstPre = root.querySelector("pre");
-    const firstCode = root.querySelector("code");
-    const firstInlineCode = root.querySelector("p code");
-    const getMetrics = (element: Element | null) => {
-      if (!(element instanceof HTMLElement)) return null;
-      const style = window.getComputedStyle(element);
-      return {
-        className: element.className,
-        fontSize: style.fontSize,
-        lineHeight: style.lineHeight,
-        fontFamily: style.fontFamily,
-      };
-    };
-    // #region agent log
-    fetch("http://127.0.0.1:7800/ingest/f3cbd1e5-6b99-4559-90b9-9eaeb44e6deb", { method: "POST", headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "157ac9" }, body: JSON.stringify({ sessionId: "157ac9", runId: "initial", hypothesisId: "H3", location: "code-output.tsx:render-metrics", message: "Captured code output typography metrics", data: { language: language ?? "text", wrapperClassName: root.className, markdownClassOverride: CODE_OUTPUT_MARKDOWN_CLASSES, preMetrics: getMetrics(firstPre), codeMetrics: getMetrics(firstCode), inlineCodeMetrics: getMetrics(firstInlineCode) }, timestamp: Date.now() }) }).catch(() => {});
-    // #endregion
-  }, [displayText, language]);
-
   return (
-    <div ref={rootRef} className={cn("rounded-md border-l-2 border-l-border-strong bg-muted px-3 py-2", className)}>
+    <div className={cn("rounded-md border-l-2 border-l-border-strong bg-muted px-3 py-2", className)}>
       {/* Header row: copy button (left) + category label (right) */}
       <div className="mb-1.5 flex items-center justify-between">
         <button

--- a/web/src/shared/components/ui/terminal-window.tsx
+++ b/web/src/shared/components/ui/terminal-window.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useCallback, useRef, useEffect } from "react";
+import { useState, useCallback, useRef } from "react";
 import { Copy, Check } from "lucide-react";
 import { cn } from "@/shared/lib/utils";
 import { useTranslation } from "@/i18n";
@@ -28,8 +28,6 @@ export function TerminalWindow({ title, children, className, copyText }: Termina
   const { t } = useTranslation();
   const [copied, setCopied] = useState(false);
   const bodyRef = useRef<HTMLDivElement>(null);
-  const titleRef = useRef<HTMLSpanElement>(null);
-
   const handleCopy = useCallback(async () => {
     const text = copyText ?? bodyRef.current?.textContent ?? "";
     try {
@@ -41,30 +39,11 @@ export function TerminalWindow({ title, children, className, copyText }: Termina
     }
   }, [copyText]);
 
-  useEffect(() => {
-    const body = bodyRef.current;
-    const titleElement = titleRef.current;
-    const firstPre = body?.querySelector("pre") ?? null;
-    const getMetrics = (element: Element | null) => {
-      if (!(element instanceof HTMLElement)) return null;
-      const style = window.getComputedStyle(element);
-      return {
-        className: element.className,
-        fontSize: style.fontSize,
-        lineHeight: style.lineHeight,
-        fontFamily: style.fontFamily,
-      };
-    };
-    // #region agent log
-    fetch("http://127.0.0.1:7800/ingest/f3cbd1e5-6b99-4559-90b9-9eaeb44e6deb", { method: "POST", headers: { "Content-Type": "application/json", "X-Debug-Session-Id": "157ac9" }, body: JSON.stringify({ sessionId: "157ac9", runId: "initial", hypothesisId: "H2", location: "terminal-window.tsx:render-metrics", message: "Captured terminal typography metrics", data: { title, className: className ?? "", titleMetrics: getMetrics(titleElement), bodyMetrics: getMetrics(body), firstPreMetrics: getMetrics(firstPre) }, timestamp: Date.now() }) }).catch(() => {});
-    // #endregion
-  }, [className, title, children]);
-
   return (
     <div className={cn("overflow-hidden rounded-md border border-[var(--color-terminal-border)]", className)}>
       {/* Title bar */}
       <div className="flex items-center justify-between border-b border-[var(--color-terminal-border)] bg-[var(--color-terminal-surface)] px-3 py-2">
-        <span ref={titleRef} className="font-mono text-sm text-[var(--color-terminal-dim)]">
+        <span className="font-mono text-sm text-[var(--color-terminal-dim)]">
           {title}
         </span>
         <button


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This addresses inconsistent markdown typography across the web app and removes accidental client-side debug traffic.

## Changes

- **Links in markdown** now use the design-system accent (`text-accent-purple` / `--color-focus`) instead of `text-primary`, which mapped to near-foreground in the theme and made links look like body text.
- **Tool output markdown** (`PROSE_CLASSES`) no longer overrides list margins, paragraph spacing, inline `code`, or `pre` blocks. Those rules fought `MarkdownRenderer`’s `prose` + custom code block chrome; the wrapper now only sets body tone (`text-muted-foreground`) and scale.
- **Thinking blocks** (`.markdown-reasoning a`) use the same focus/accent color and solid underline for parity with main markdown.
- **Removed** `fetch` calls to `127.0.0.1:7800` from `MarkdownRenderer`, `code-output`, `terminal-window`, and the unused `selectedRenderer` / effect in `ToolOutputRenderer`.

## Testing

- `make lint-web` could not run in this environment: `npm install` fails on an existing `@eslint/js` vs `eslint` peer conflict. Local verification after resolving install is recommended.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-efeef281-c703-473c-83f6-7522cc1ae886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-efeef281-c703-473c-83f6-7522cc1ae886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

