### PR TITLE
chore(web): remove debug console logging

### DIFF
--- a/web/src/app/api/[...proxy]/route.ts
+++ b/web/src/app/api/[...proxy]/route.ts
@@ -12,16 +12,6 @@ const PROXY_SECRET = process.env.PROXY_SECRET ?? "";
 async function handler(req: NextRequest) {
   const session = await auth();
 
-  // Debug: log session state for API requests
-  if (process.env.NODE_ENV === "development") {
-    const { pathname } = req.nextUrl;
-    console.log("[proxy]", req.method, pathname, {
-      hasSession: !!session,
-      user: session?.user?.email ?? "none",
-      googleId: session?.user?.googleId ?? "none",
-    });
-  }
-
   // Build the backend URL: /api/conversations/123 → http://backend/conversations/123
   const { pathname, search } = req.nextUrl;
   const backendPath = pathname.replace(/^\/api/, "");

--- a/web/src/app/auth/desktop-callback/page.tsx
+++ b/web/src/app/auth/desktop-callback/page.tsx
@@ -38,7 +38,6 @@ function CallbackContent() {
       image: user.image ?? "",
       googleId: user.googleId ?? "",
     };
-    console.log("[desktop-callback] Posting token with nonce:", nonce, payload);
 
     fetch("/api/auth/desktop-token", {
       method: "POST",
@@ -47,7 +46,6 @@ function CallbackContent() {
     })
       .then(async (res) => {
         const body = await res.text();
-        console.log("[desktop-callback] Response:", res.status, body);
         if (res.ok) {
           setDone(true);
         } else {

--- a/web/src/shared/hooks/use-sse.ts
+++ b/web/src/shared/hooks/use-sse.ts
@@ -337,10 +337,6 @@ export function useSSE(conversationId: string | null, isLive = true) {
             const agentEvent = parseSSEEvent(e.data, eventName as EventType);
             if (!agentEvent) return;
 
-            if (agentEvent.type === "ask_user" && process.env.NODE_ENV === "development") {
-              console.log("[SSE] ask_user event received:", JSON.stringify(agentEvent.data));
-            }
-
             enqueueEvent(agentEvent);
           } catch {
             // Skip malformed events


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Removes leftover debug `console.log` calls and dev-only proxy/SSE tracing from the Next.js app. Error logging (`console.error`) on real failure paths is unchanged.

## Changes

- **Desktop OAuth callback** — dropped logs that printed nonce, user payload, and raw response bodies (sensitive in devtools).
- **API proxy route** — removed development-only session snapshot logging for every proxied request.
- **SSE hook** — removed development-only `ask_user` event payload dumps.

## Testing

- `make lint-web` could not run locally: `npm install` fails with an `@eslint/js` / `eslint` peer dependency conflict (pre-existing). IDE diagnostics report no issues on the touched files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52de513a-d8d0-47ef-89b0-5e48e658cde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52de513a-d8d0-47ef-89b0-5e48e658cde7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

