### PR TITLE
fix(web): conversation panel AI reply rendering (think tags, cursor, keys)

### DIFF
--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -640,10 +640,20 @@ pre, code {
 .markdown-body.streaming-active > h2:last-child::after,
 .markdown-body.streaming-active > h3:last-child::after,
 .markdown-body.streaming-active > h4:last-child::after,
+.markdown-body.streaming-active > h5:last-child::after,
+.markdown-body.streaming-active > h6:last-child::after,
+.markdown-body.streaming-active > div:not(.not-prose):last-child pre:last-child::after,
+.markdown-body.streaming-active > pre:last-child::after,
 .markdown-reasoning.streaming-active:empty::after,
 .markdown-reasoning.streaming-active > p:last-child::after,
 .markdown-reasoning.streaming-active > ul:last-child > li:last-child::after,
-.markdown-reasoning.streaming-active > ol:last-child > li:last-child::after {
+.markdown-reasoning.streaming-active > ol:last-child > li:last-child::after,
+.markdown-reasoning.streaming-active > h1:last-child::after,
+.markdown-reasoning.streaming-active > h2:last-child::after,
+.markdown-reasoning.streaming-active > h3:last-child::after,
+.markdown-reasoning.streaming-active > h4:last-child::after,
+.markdown-reasoning.streaming-active > h5:last-child::after,
+.markdown-reasoning.streaming-active > h6:last-child::after {
   content: "";
   display: inline-block;
   vertical-align: baseline;

--- a/web/src/features/agent-computer/hooks/use-agent-state.test.ts
+++ b/web/src/features/agent-computer/hooks/use-agent-state.test.ts
@@ -3,6 +3,46 @@ import { deriveAgentState } from "./use-agent-state";
 import type { AgentEvent } from "../../../shared/types";
 
 describe("deriveAgentState", () => {
+  it("strips inline redacted_thinking blocks from llm_response text into thinkingContent", () => {
+    const events: AgentEvent[] = [
+      {
+        type: "llm_response",
+        data: {
+          text: "<redacted_thinking>plan A</redacted_thinking>\n\nHello **world**",
+        },
+        timestamp: 1,
+        iteration: 1,
+      },
+    ];
+
+    const state = deriveAgentState(events);
+    expect(state.messages).toHaveLength(1);
+    expect(state.messages[0]?.content).toBe("Hello **world**");
+    expect(state.messages[0]?.thinkingContent).toBe("plan A");
+  });
+
+  it("strips legacy think blocks and merges with prior thinking events", () => {
+    const events: AgentEvent[] = [
+      {
+        type: "thinking",
+        data: { thinking: "from event" },
+        timestamp: 1,
+        iteration: 1,
+      },
+      {
+        type: "llm_response",
+        data: { text: "<redacted_thinking>inline</think>Done." },
+        timestamp: 2,
+        iteration: 1,
+      },
+    ];
+
+    const state = deriveAgentState(events);
+    expect(state.messages[0]?.content).toBe("Done.");
+    expect(state.messages[0]?.thinkingContent).toContain("from event");
+    expect(state.messages[0]?.thinkingContent).toContain("inline");
+  });
+
   it("uses llm_response.content when text is missing", () => {
     const events: AgentEvent[] = [
       {

--- a/web/src/features/agent-computer/hooks/use-agent-state.ts
+++ b/web/src/features/agent-computer/hooks/use-agent-state.ts
@@ -2,16 +2,25 @@
 
 import { useMemo, useRef } from "react";
 
-// Some LLM providers (e.g. Qwen3 via DashScope) embed thinking content in
-// the response text using <think>…</think> tags rather than returning it as
-// a separate content block.  Split them out so we can display the reasoning
-// in a dedicated ThinkingBlock instead of raw prose.
-const THINK_TAG_RE = /^<think>([\s\S]*?)<\/think>\s*/;
+// Some models embed chain-of-thought in the assistant text using `<redacted_thinking>…</redacted_thinking>`
+// (see `agent/llm/client._split_think_tags`) or legacy `<redacted_thinking>…</think>` pairs.
+// Strip every block so reasoning appears in ThinkingBlock, not in the markdown body.
+const INLINE_THINK_PATTERNS = [
+  /<redacted_thinking>([\s\S]*?)<\/redacted_thinking>/gi,
+  /<redacted_thinking>([\s\S]*?)<\/think>/gi,
+];
 
 function splitThinkTag(text: string): { thinking: string; content: string } {
-  const m = THINK_TAG_RE.exec(text);
-  if (!m) return { thinking: "", content: text };
-  return { thinking: m[1].trim(), content: text.slice(m[0].length) };
+  const thinkingParts: string[] = [];
+  let clean = text;
+  for (const re of INLINE_THINK_PATTERNS) {
+    clean = clean.replace(re, (_match, inner: string) => {
+      const trimmed = inner.trim();
+      if (trimmed) thinkingParts.push(trimmed);
+      return "";
+    });
+  }
+  return { thinking: thinkingParts.join("\n\n"), content: clean.trim() };
 }
 
 import type {

--- a/web/src/features/channels/components/ChannelChatView.tsx
+++ b/web/src/features/channels/components/ChannelChatView.tsx
@@ -150,6 +150,7 @@ export function ChannelChatView({ conversation, hideTopBar }: ChannelChatViewPro
               msg.thinkingEntries && msg.thinkingEntries.length > 0
                 ? [...(existing.thinkingEntries ?? []), ...msg.thinkingEntries]
                 : existing.thinkingEntries,
+            thinkingContent: existing.thinkingContent || msg.thinkingContent,
           };
         }
       }

--- a/web/src/features/conversation/components/ConversationWorkspace.tsx
+++ b/web/src/features/conversation/components/ConversationWorkspace.tsx
@@ -18,6 +18,10 @@ import {
   getLatestTurnMode,
   getPlanMessageIndex,
 } from "./conversation-mode";
+import {
+  buildAssistantCopyText,
+  isThinkingContentRedundantWithEntries,
+} from "../lib/assistant-copy-text";
 import { cn } from "@/shared/lib/utils";
 import { formatClockTime } from "@/shared/lib/date-time";
 import { useTranslation } from "@/i18n";
@@ -61,24 +65,6 @@ interface ConversationWorkspaceProps {
 // ── Memoized message row ─────────────────────────────────────────────
 // Prevents non-streaming messages from re-rendering when only the last
 // (streaming) message content changes.
-
-/** True when `thinkingContent` duplicates what is already shown via `thinkingEntries`. */
-function isThinkingContentRedundantWithEntries(
-  thinkingContent: string | undefined,
-  entries: readonly ThinkingEntry[] | undefined,
-): boolean {
-  const trimmed = thinkingContent?.trim();
-  if (!trimmed || !entries?.length) return false;
-  const combined = entries
-    .map((e) => e.content.trim())
-    .filter(Boolean)
-    .join("\n\n")
-    .trim();
-  if (!combined) return false;
-  if (trimmed === combined) return true;
-  const collapse = (s: string) => s.replace(/\s+/g, " ").trim();
-  return collapse(trimmed) === collapse(combined);
-}
 
 interface MessageRowProps {
   readonly msg: ChatMessage;
@@ -144,6 +130,14 @@ const MessageRow = memo(function MessageRow({
     !hasPlanHere &&
     !hasThinking;
 
+  const thinkingEntryCount = msg.thinkingEntries?.length ?? 0;
+  const copyAssistantText = buildAssistantCopyText(msg, {
+    hasEmbeddedPlan: hasPlanHere,
+    planSteps,
+    imageUrls,
+    t,
+  });
+
   return (
     <div data-role={msg.role} className={cn(index > 0 && "mt-4")}>
       {msg.role === "user" ? (
@@ -203,7 +197,11 @@ const MessageRow = memo(function MessageRow({
                   <ThinkingBlock
                     key={`${msg.messageId ?? msg.timestamp}-thinking-${idx}`}
                     content={entry.content}
-                    isThinking={isLastAssistant && assistantPhase.phase === "thinking"}
+                    isThinking={
+                      isLastAssistant
+                      && assistantPhase.phase === "thinking"
+                      && idx === thinkingEntryCount - 1
+                    }
                     isTurnStreaming={isLastAssistant ? isStreaming : false}
                     durationMs={entry.durationMs}
                   />
@@ -271,7 +269,7 @@ const MessageRow = memo(function MessageRow({
                       type="button"
                       variant="ghost"
                       size="icon-xs"
-                      onClick={() => onCopy(msg.content)}
+                      onClick={() => onCopy(copyAssistantText.trim() || msg.content)}
                       className="text-muted-foreground-dim hover:text-foreground hover:bg-secondary active:translate-y-[0.5px]"
                     >
                       {copied

--- a/web/src/features/conversation/components/ConversationWorkspace.tsx
+++ b/web/src/features/conversation/components/ConversationWorkspace.tsx
@@ -62,6 +62,24 @@ interface ConversationWorkspaceProps {
 // Prevents non-streaming messages from re-rendering when only the last
 // (streaming) message content changes.
 
+/** True when `thinkingContent` duplicates what is already shown via `thinkingEntries`. */
+function isThinkingContentRedundantWithEntries(
+  thinkingContent: string | undefined,
+  entries: readonly ThinkingEntry[] | undefined,
+): boolean {
+  const trimmed = thinkingContent?.trim();
+  if (!trimmed || !entries?.length) return false;
+  const combined = entries
+    .map((e) => e.content.trim())
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  if (!combined) return false;
+  if (trimmed === combined) return true;
+  const collapse = (s: string) => s.replace(/\s+/g, " ").trim();
+  return collapse(trimmed) === collapse(combined);
+}
+
 interface MessageRowProps {
   readonly msg: ChatMessage;
   readonly isLastAssistant: boolean;
@@ -113,7 +131,11 @@ const MessageRow = memo(function MessageRow({
 
   const imageUrls = getImageUrlsForMessage(msg);
   const hasPlanHere = index === planMessageIndex && planSteps.length > 0;
-  const hasThinking = Boolean(msg.thinkingEntries && msg.thinkingEntries.length > 0);
+  const showOrphanThinkingContent =
+    Boolean(msg.thinkingContent?.trim())
+    && !isThinkingContentRedundantWithEntries(msg.thinkingContent, msg.thinkingEntries);
+  const hasThinking =
+    Boolean(msg.thinkingEntries && msg.thinkingEntries.length > 0) || showOrphanThinkingContent;
   const trimmedContent = msg.content.trim();
   const showMarkdown = trimmedContent.length > 0 || isStreamingThis;
   const showEmptyAssistantPlaceholder =
@@ -174,21 +196,31 @@ const MessageRow = memo(function MessageRow({
           )}
         >
           <div className="relative">
-            {/* Thinking blocks for this assistant message */}
-            {msg.thinkingEntries && msg.thinkingEntries.length > 0 && (
+            {/* Reasoning: event-sourced entries first, then inline-only thinkingContent (not duplicated). */}
+            {hasThinking ? (
               <div className="mb-3 space-y-2">
-                {msg.thinkingEntries.map((entry, idx) => (
+                {msg.thinkingEntries?.map((entry, idx) => (
                   <ThinkingBlock
-                    key={`${msg.timestamp}-thinking-${idx}`}
+                    key={`${msg.messageId ?? msg.timestamp}-thinking-${idx}`}
                     content={entry.content}
                     isThinking={isLastAssistant && assistantPhase.phase === "thinking"}
                     isTurnStreaming={isLastAssistant ? isStreaming : false}
                     durationMs={entry.durationMs}
                   />
                 ))}
+                {showOrphanThinkingContent ? (
+                  <ThinkingBlock
+                    key={`${msg.messageId ?? msg.timestamp}-thinking-content`}
+                    content={msg.thinkingContent!}
+                    isThinking={false}
+                    isTurnStreaming={isLastAssistant ? isStreaming : false}
+                    durationMs={0}
+                    summaryLabel={t("thinking.reasoning")}
+                  />
+                ) : null}
               </div>
-            )}
-            {/* Message body */}
+            ) : null}
+            {/* Message body: prose, then images, then embedded plan (matches read order). */}
             <div className="conversation-response-body text-sm leading-[1.5] text-foreground">
               {showMarkdown ? (
                 <MarkdownRenderer content={msg.content} isStreaming={isStreamingThis} />

--- a/web/src/features/conversation/components/ConversationWorkspace.tsx
+++ b/web/src/features/conversation/components/ConversationWorkspace.tsx
@@ -111,6 +111,17 @@ const MessageRow = memo(function MessageRow({
     [conversationId],
   );
 
+  const imageUrls = getImageUrlsForMessage(msg);
+  const hasPlanHere = index === planMessageIndex && planSteps.length > 0;
+  const hasThinking = Boolean(msg.thinkingEntries && msg.thinkingEntries.length > 0);
+  const trimmedContent = msg.content.trim();
+  const showMarkdown = trimmedContent.length > 0 || isStreamingThis;
+  const showEmptyAssistantPlaceholder =
+    !showMarkdown &&
+    imageUrls.length === 0 &&
+    !hasPlanHere &&
+    !hasThinking;
+
   return (
     <div data-role={msg.role} className={cn(index > 0 && "mt-4")}>
       {msg.role === "user" ? (
@@ -179,27 +190,29 @@ const MessageRow = memo(function MessageRow({
             )}
             {/* Message body */}
             <div className="conversation-response-body text-sm leading-[1.5] text-foreground">
-              <MarkdownRenderer content={msg.content} isStreaming={isStreamingThis} />
+              {showMarkdown ? (
+                <MarkdownRenderer content={msg.content} isStreaming={isStreamingThis} />
+              ) : null}
+              {showEmptyAssistantPlaceholder ? (
+                <p className="text-muted-foreground">{t("conversation.emptyAssistantBody")}</p>
+              ) : null}
 
               {/* Inline images for this message */}
-              {(() => {
-                const imageUrls = getImageUrlsForMessage(msg);
-                return imageUrls.length > 0 ? (
-                  <div className="mt-4 flex flex-wrap gap-3">
-                    {imageUrls.map((url) => (
-                      <img
-                        key={url}
-                        src={url}
-                        alt={t("conversation.imageAlt")}
-                        className="max-h-72 max-w-full rounded-md object-contain"
-                        onError={(e) => {
-                          (e.currentTarget as HTMLImageElement).style.display = "none";
-                        }}
-                      />
-                    ))}
-                  </div>
-                ) : null;
-              })()}
+              {imageUrls.length > 0 ? (
+                <div className="mt-4 flex flex-wrap gap-3">
+                  {imageUrls.map((url) => (
+                    <img
+                      key={url}
+                      src={url}
+                      alt={t("conversation.imageAlt")}
+                      className="max-h-72 max-w-full rounded-md object-contain"
+                      onError={(e) => {
+                        (e.currentTarget as HTMLImageElement).style.display = "none";
+                      }}
+                    />
+                  ))}
+                </div>
+              ) : null}
 
               {/* Plan checklist embedded in this message */}
               {index === planMessageIndex && planSteps.length > 0 && (
@@ -431,8 +444,7 @@ export function ConversationWorkspace({
               {messages.map((msg, i) => {
                 const isLastAssistant = msg.role === "assistant" && i === messages.length - 1;
                 const isStreamingThis = isStreaming && isLastAssistant;
-                // Stable key: role + timestamp (no array index)
-                const messageKey = `${msg.role}-${msg.timestamp}`;
+                const messageKey = msg.messageId ?? `${msg.role}-${msg.timestamp}-${i}`;
 
                 return (
                   <MessageRow

--- a/web/src/features/conversation/components/ThinkingBlock.tsx
+++ b/web/src/features/conversation/components/ThinkingBlock.tsx
@@ -12,6 +12,8 @@ interface ThinkingBlockProps {
   readonly isThinking: boolean;
   readonly isTurnStreaming: boolean;
   readonly durationMs?: number;
+  /** When set, used instead of "Thought for Ns" when not actively thinking (e.g. inline-extracted reasoning). */
+  readonly summaryLabel?: string;
 }
 
 export function ThinkingBlock({
@@ -19,6 +21,7 @@ export function ThinkingBlock({
   isThinking,
   isTurnStreaming,
   durationMs = 0,
+  summaryLabel,
 }: ThinkingBlockProps) {
   const { t } = useTranslation();
   const shouldReduceMotion = useReducedMotion();
@@ -66,7 +69,7 @@ export function ThinkingBlock({
   const durationSeconds = Math.max(Math.round(durationMs / 1000), 1);
   const label = isThinking
     ? t("thinking.thinking")
-    : t("thinking.thoughtFor", { seconds: durationSeconds });
+    : (summaryLabel ?? t("thinking.thoughtFor", { seconds: durationSeconds }));
 
   return (
     <div className="overflow-hidden border-l border-border-strong pl-2">

--- a/web/src/features/conversation/lib/assistant-copy-text.test.ts
+++ b/web/src/features/conversation/lib/assistant-copy-text.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "@jest/globals";
+import { buildAssistantCopyText, isThinkingContentRedundantWithEntries } from "./assistant-copy-text";
+import type { ChatMessage, PlanStep } from "@/shared/types";
+
+const t = (key: string) => {
+  const map: Record<string, string> = {
+    "conversation.copySectionReasoning": "Reasoning",
+    "conversation.copySectionAnswer": "Answer",
+    "conversation.copySectionPlan": "Plan",
+    "conversation.copySectionImages": "Images",
+  };
+  return map[key] ?? key;
+};
+
+describe("isThinkingContentRedundantWithEntries", () => {
+  it("returns false when thinkingContent is missing", () => {
+    expect(isThinkingContentRedundantWithEntries(undefined, [{ content: "a" }])).toBe(false);
+  });
+
+  it("returns true when content matches joined entries", () => {
+    expect(
+      isThinkingContentRedundantWithEntries("a\n\nb", [
+        { content: "a" },
+        { content: "b" },
+      ]),
+    ).toBe(true);
+  });
+});
+
+describe("buildAssistantCopyText", () => {
+  it("includes reasoning, answer, plan, and image URLs in order", () => {
+    const msg: ChatMessage = {
+      role: "assistant",
+      content: "Hello",
+      timestamp: 1,
+      thinkingEntries: [{ content: "step 1", timestamp: 0, durationMs: 0 }],
+      thinkingContent: "extra",
+    };
+    const planSteps: PlanStep[] = [
+      {
+        name: "Research",
+        description: "Look up docs",
+        executionType: "parallel_worker",
+        status: "complete",
+      },
+    ];
+    const text = buildAssistantCopyText(msg, {
+      hasEmbeddedPlan: true,
+      planSteps,
+      imageUrls: ["https://example.com/a.png"],
+      t,
+    });
+    expect(text).toContain("Reasoning");
+    expect(text).toContain("step 1");
+    expect(text).toContain("extra");
+    expect(text).toContain("Answer");
+    expect(text).toContain("Hello");
+    expect(text).toContain("Plan");
+    expect(text).toContain("[complete] Research");
+    expect(text).toContain("Images");
+    expect(text).toContain("https://example.com/a.png");
+    expect(text.indexOf("Reasoning")).toBeLessThan(text.indexOf("Answer"));
+    expect(text.indexOf("Answer")).toBeLessThan(text.indexOf("Plan"));
+    expect(text.indexOf("Plan")).toBeLessThan(text.indexOf("Images"));
+  });
+
+  it("omits redundant thinkingContent when it matches entries", () => {
+    const msg: ChatMessage = {
+      role: "assistant",
+      content: "Hi",
+      timestamp: 1,
+      thinkingEntries: [{ content: "same", timestamp: 0, durationMs: 0 }],
+      thinkingContent: "same",
+    };
+    const text = buildAssistantCopyText(msg, {
+      hasEmbeddedPlan: false,
+      planSteps: [],
+      imageUrls: [],
+      t,
+    });
+    expect(text.match(/same/g)?.length).toBe(1);
+  });
+});

--- a/web/src/features/conversation/lib/assistant-copy-text.ts
+++ b/web/src/features/conversation/lib/assistant-copy-text.ts
@@ -1,0 +1,72 @@
+import type { ChatMessage, PlanStep } from "@/shared/types";
+
+/** True when `thinkingContent` duplicates what is already shown via `thinkingEntries`. */
+export function isThinkingContentRedundantWithEntries(
+  thinkingContent: string | undefined,
+  entries: readonly { readonly content: string }[] | undefined,
+): boolean {
+  const trimmed = thinkingContent?.trim();
+  if (!trimmed || !entries?.length) return false;
+  const combined = entries
+    .map((e) => e.content.trim())
+    .filter(Boolean)
+    .join("\n\n")
+    .trim();
+  if (!combined) return false;
+  if (trimmed === combined) return true;
+  const collapse = (s: string) => s.replace(/\s+/g, " ").trim();
+  return collapse(trimmed) === collapse(combined);
+}
+
+export interface BuildAssistantCopyTextOptions {
+  readonly hasEmbeddedPlan: boolean;
+  readonly planSteps: readonly PlanStep[];
+  readonly imageUrls: readonly string[];
+  readonly t: (key: string) => string;
+}
+
+/**
+ * Plain text for clipboard: reasoning (entries + non-redundant thinkingContent), answer,
+ * embedded plan steps, and image URLs when present.
+ */
+export function buildAssistantCopyText(
+  msg: ChatMessage,
+  options: BuildAssistantCopyTextOptions,
+): string {
+  const { hasEmbeddedPlan, planSteps, imageUrls, t } = options;
+  const chunks: string[] = [];
+
+  const entryTexts = (msg.thinkingEntries ?? [])
+    .map((e) => e.content.trim())
+    .filter(Boolean);
+  const showOrphan =
+    Boolean(msg.thinkingContent?.trim())
+    && !isThinkingContentRedundantWithEntries(msg.thinkingContent, msg.thinkingEntries);
+  const orphanText = showOrphan ? msg.thinkingContent!.trim() : "";
+
+  if (entryTexts.length > 0 || orphanText) {
+    const body = [...entryTexts, orphanText].filter(Boolean).join("\n\n");
+    chunks.push(`${t("conversation.copySectionReasoning")}\n\n${body}`);
+  }
+
+  const answer = msg.content.trim();
+  if (answer.length > 0) {
+    chunks.push(`${t("conversation.copySectionAnswer")}\n\n${answer}`);
+  }
+
+  if (hasEmbeddedPlan && planSteps.length > 0) {
+    const lines = planSteps.map((step, i) => {
+      const detail = step.description.trim()
+        ? `: ${step.description.trim()}`
+        : "";
+      return `${i + 1}. [${step.status}] ${step.name.trim()}${detail}`;
+    });
+    chunks.push(`${t("conversation.copySectionPlan")}\n\n${lines.join("\n")}`);
+  }
+
+  if (imageUrls.length > 0) {
+    chunks.push(`${t("conversation.copySectionImages")}\n\n${imageUrls.map((u) => `- ${u}`).join("\n")}`);
+  }
+
+  return chunks.join("\n\n---\n\n");
+}

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -71,6 +71,10 @@
   "conversation.retry": "Retry",
   "conversation.imageAlt": "AI-generated image artifact",
   "conversation.emptyAssistantBody": "No text in this reply.",
+  "conversation.copySectionReasoning": "Reasoning",
+  "conversation.copySectionAnswer": "Answer",
+  "conversation.copySectionPlan": "Plan",
+  "conversation.copySectionImages": "Images",
 
   "progress.taskStarted": "Task Started",
   "progress.reasoning": "Thinking",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -70,6 +70,7 @@
   "conversation.copy": "Copy",
   "conversation.retry": "Retry",
   "conversation.imageAlt": "AI-generated image artifact",
+  "conversation.emptyAssistantBody": "No text in this reply.",
 
   "progress.taskStarted": "Task Started",
   "progress.reasoning": "Thinking",

--- a/web/src/i18n/locales/en.json
+++ b/web/src/i18n/locales/en.json
@@ -89,6 +89,7 @@
   "progress.reasoningLive": "Thinking...",
   "thinking.thinking": "Thinking...",
   "thinking.thoughtFor": "Thought for {seconds}s",
+  "thinking.reasoning": "Reasoning",
   "progress.complete": "Complete",
   "progress.stateIdle": "Idle",
   "progress.statePlanning": "Planning",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -71,6 +71,10 @@
   "conversation.retry": "重试",
   "conversation.imageAlt": "AI 生成的图片",
   "conversation.emptyAssistantBody": "此回复没有文字内容。",
+  "conversation.copySectionReasoning": "推理",
+  "conversation.copySectionAnswer": "回答",
+  "conversation.copySectionPlan": "计划",
+  "conversation.copySectionImages": "图片",
 
   "progress.taskStarted": "任务已开始",
   "progress.reasoning": "思考中",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -70,6 +70,7 @@
   "conversation.copy": "复制",
   "conversation.retry": "重试",
   "conversation.imageAlt": "AI 生成的图片",
+  "conversation.emptyAssistantBody": "此回复没有文字内容。",
 
   "progress.taskStarted": "任务已开始",
   "progress.reasoning": "思考中",

--- a/web/src/i18n/locales/zh-CN.json
+++ b/web/src/i18n/locales/zh-CN.json
@@ -89,6 +89,7 @@
   "progress.reasoningLive": "思考中...",
   "thinking.thinking": "思考中...",
   "thinking.thoughtFor": "思考了 {seconds} 秒",
+  "thinking.reasoning": "推理",
   "progress.complete": "完成",
   "progress.stateIdle": "就绪",
   "progress.statePlanning": "规划中",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -71,6 +71,10 @@
   "conversation.retry": "重試",
   "conversation.imageAlt": "AI 生成的圖片",
   "conversation.emptyAssistantBody": "此則回覆沒有文字內容。",
+  "conversation.copySectionReasoning": "推理",
+  "conversation.copySectionAnswer": "回答",
+  "conversation.copySectionPlan": "計畫",
+  "conversation.copySectionImages": "圖片",
 
   "progress.taskStarted": "任務已開始",
   "progress.reasoning": "思考中",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -89,6 +89,7 @@
   "progress.reasoningLive": "思考中...",
   "thinking.thinking": "思考中...",
   "thinking.thoughtFor": "思考了 {seconds} 秒",
+  "thinking.reasoning": "推理",
   "progress.complete": "完成",
   "progress.stateIdle": "就緒",
   "progress.statePlanning": "規劃中",

--- a/web/src/i18n/locales/zh-TW.json
+++ b/web/src/i18n/locales/zh-TW.json
@@ -70,6 +70,7 @@
   "conversation.copy": "複製",
   "conversation.retry": "重試",
   "conversation.imageAlt": "AI 生成的圖片",
+  "conversation.emptyAssistantBody": "此則回覆沒有文字內容。",
 
   "progress.taskStarted": "任務已開始",
   "progress.reasoning": "思考中",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes several issues in how assistant replies are derived and shown in the conversation panel (and channel chat parity).

## Changes

- **Inline reasoning tags**: `deriveAgentState` strips every occurrence of backend-style `redacted_thinking` / `redacted_thinking` blocks (aligned with `agent/llm/client._split_think_tags`) and legacy `redacted_thinking` / `think` pairs, so chain-of-thought is merged into `thinkingContent` / ThinkingBlock instead of leaking into markdown.
- **Render ordering**: Assistant rows show **thinking entries first**, then **`thinkingContent` when it is not redundant** with those entries, then **markdown**, **images**, **embedded plan**. `ThinkingBlock` supports **`summaryLabel`** (`thinking.reasoning`) for inline-only blocks without a duration.
- **Copy**: The assistant **Copy** action copies a structured plain-text transcript: **Reasoning** (entries + non-redundant `thinkingContent`), **Answer**, **Plan** (when embedded on that message), and **Images** (artifact URLs). Sections are separated by `---`. If everything except the raw body is empty, it falls back to `msg.content`.
- **Thinking pulse**: Only the **last** `thinkingEntries` block on the latest assistant shows the active “Thinking…” state when `assistantPhase.phase === "thinking"` (avoids every block pulsing at once).
- **Channel parity**: `ChannelChatView` duplicate merge carries **`thinkingContent`** when deduping event vs history rows.
- **Streaming cursor**: Extended `.streaming-active` rules for fenced code (wrapped `pre`), `h5`/`h6`, and reasoning markdown headings.
- **Stable list keys**: Message rows use `messageId` when provided, falling back to `role-timestamp-index`.
- **Empty body**: Localized placeholder when there is no markdown body (unless streaming / images / plan / thinking).

## Tests

- `make test-web` (Jest): inline think stripping, merge with prior `thinking` events, and `buildAssistantCopyText` / redundancy helper.

## Notes

Local `npm install` may require `npm install --legacy-peer-deps` due to existing eslint peer resolution; CI should match your usual web install path.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2634b999-59ce-49da-a700-480a1f318467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2634b999-59ce-49da-a700-480a1f318467"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

