### PR TITLE
Fix SSE /events reconnect churn and remove debug instrumentation

### DIFF
--- a/backend/agent/llm/client.py
+++ b/backend/agent/llm/client.py
@@ -3,9 +3,6 @@
 import asyncio
 import json
 import re
-import time
-from pathlib import Path
-from uuid import uuid4
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
 from typing import Any
@@ -20,36 +17,6 @@ _CONTENT_POLICY_ERROR_SUMMARY = (
     "Model provider rejected the request because the prompt or recent tool "
     "output triggered content inspection."
 )
-_DEBUG_LOG_PATH = Path("/Users/feihe/Workspace/Synapse/.cursor/debug-caca61.log")
-_DEBUG_SESSION_ID = "caca61"
-
-
-def _emit_debug_log(
-    *,
-    run_id: str,
-    hypothesis_id: str,
-    location: str,
-    message: str,
-    data: dict[str, Any],
-) -> None:
-    payload = {
-        "sessionId": _DEBUG_SESSION_ID,
-        "id": f"log_{uuid4().hex}",
-        "timestamp": int(time.time() * 1000),
-        "runId": run_id,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-    }
-    try:
-        _DEBUG_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with _DEBUG_LOG_PATH.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, ensure_ascii=True) + "\n")
-    except Exception:
-        return
-
-
 class LLMContentPolicyError(RuntimeError):
     """Raised when the provider rejects a request due to content inspection."""
 
@@ -467,57 +434,9 @@ class AnthropicClient:
             if kwargs["max_tokens"] < min_max_tokens:
                 kwargs["max_tokens"] = min_max_tokens
 
-        message_chars = sum(
-            len(json.dumps(message, ensure_ascii=True)) for message in messages
-        )
-        tool_chars = len(json.dumps(tools or [], ensure_ascii=True))
-        # region agent log
-        _emit_debug_log(
-            run_id="initial",
-            hypothesis_id="H1",
-            location="backend/agent/llm/client.py:create_message_stream:request",
-            message="Prepared stream request payload stats",
-            data={
-                "model": effective_model,
-                "messageCount": len(messages),
-                "messageChars": message_chars,
-                "systemChars": len(system),
-                "toolCount": len(tools or []),
-                "toolSchemaChars": tool_chars,
-            },
-        )
-        # endregion
-        # region agent log
-        _emit_debug_log(
-            run_id="initial",
-            hypothesis_id="H2",
-            location="backend/agent/llm/client.py:create_message_stream:thinking",
-            message="Prepared stream token budget settings",
-            data={
-                "model": effective_model,
-                "thinkingBudget": thinking_budget,
-                "maxTokens": kwargs["max_tokens"],
-                "thinkingEnabled": "thinking" in kwargs,
-            },
-        )
-        # endregion
-
         last_exc: Exception | None = None
         for attempt in range(_MAX_RETRIES):
             try:
-                # region agent log
-                _emit_debug_log(
-                    run_id="initial",
-                    hypothesis_id="H4",
-                    location="backend/agent/llm/client.py:create_message_stream:attempt",
-                    message="Starting stream attempt",
-                    data={
-                        "model": effective_model,
-                        "attempt": attempt + 1,
-                        "maxRetries": _MAX_RETRIES,
-                    },
-                )
-                # endregion
                 async with self._client.messages.stream(**kwargs) as stream:
                     thinking_snapshot = ""
                     emitted_thinking = False
@@ -575,21 +494,7 @@ class AnthropicClient:
                 )
                 if attempt < _MAX_RETRIES - 1:
                     await asyncio.sleep(2**attempt)
-            except Exception as exc:
-                # region agent log
-                _emit_debug_log(
-                    run_id="initial",
-                    hypothesis_id="H5",
-                    location="backend/agent/llm/client.py:create_message_stream:error",
-                    message="Non-retryable stream error details",
-                    data={
-                        "model": effective_model,
-                        "errorType": type(exc).__name__,
-                        "errorText": str(exc)[:500],
-                        "providerPayload": _extract_error_payload(exc),
-                    },
-                )
-                # endregion
+            except Exception:
                 raise
 
         raise last_exc  # type: ignore[misc]

--- a/backend/agent/runtime/orchestrator.py
+++ b/backend/agent/runtime/orchestrator.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import json
-import time
 from dataclasses import dataclass, replace
-from pathlib import Path
 from typing import Any
-from uuid import uuid4
 
 from loguru import logger
 
@@ -46,36 +42,6 @@ from agent.tools.executor import ToolExecutor
 from agent.tools.registry import ToolRegistry
 from api.events import EventEmitter, EventType
 from config.settings import get_settings
-
-_DEBUG_LOG_PATH = Path("/Users/feihe/Workspace/Synapse/.cursor/debug-caca61.log")
-_DEBUG_SESSION_ID = "caca61"
-
-
-def _emit_debug_log(
-    *,
-    run_id: str,
-    hypothesis_id: str,
-    location: str,
-    message: str,
-    data: dict[str, Any],
-) -> None:
-    payload = {
-        "sessionId": _DEBUG_SESSION_ID,
-        "id": f"log_{uuid4().hex}",
-        "timestamp": int(time.time() * 1000),
-        "runId": run_id,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-    }
-    try:
-        _DEBUG_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with _DEBUG_LOG_PATH.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, ensure_ascii=True) + "\n")
-    except Exception:
-        return
-
 
 @dataclass(frozen=True)
 class AgentState:
@@ -620,25 +586,6 @@ class AgentOrchestrator:
             )
 
         llm_model = getattr(self._client, "default_model", "<unknown>")
-        message_chars = sum(
-            len(json.dumps(message, ensure_ascii=True)) for message in state.messages
-        )
-        # region agent log
-        _emit_debug_log(
-            run_id="initial",
-            hypothesis_id="H3",
-            location="backend/agent/runtime/orchestrator.py:_run_iteration:pre_call",
-            message="Orchestrator pre-LLM payload stats",
-            data={
-                "model": llm_model,
-                "iteration": state.iteration,
-                "messageCount": len(state.messages),
-                "messageChars": message_chars,
-                "toolCount": len(tools),
-                "systemPromptChars": len(effective_prompt),
-            },
-        )
-        # endregion
         try:
             thinking_emitted_during_stream = False
 
@@ -677,20 +624,6 @@ class AgentOrchestrator:
                     raise
                 response = await self._client.create_message_stream(**stream_kwargs)
         except Exception as exc:
-            # region agent log
-            _emit_debug_log(
-                run_id="initial",
-                hypothesis_id="H5",
-                location="backend/agent/runtime/orchestrator.py:_run_iteration:exception",
-                message="Orchestrator captured LLM exception",
-                data={
-                    "model": llm_model,
-                    "iteration": state.iteration,
-                    "errorType": type(exc).__name__,
-                    "errorText": str(exc)[:500],
-                },
-            )
-            # endregion
             logger.error("llm_call_failed model={} error={}", llm_model, exc)
             return state.mark_error(format_llm_failure(exc))
 

--- a/backend/agent/runtime/task_runner.py
+++ b/backend/agent/runtime/task_runner.py
@@ -3,12 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import json
 import time
 from dataclasses import dataclass, replace
-from pathlib import Path
 from typing import Any, Literal
-from uuid import uuid4
 
 from agent.llm.client import AnthropicClient, format_llm_failure
 from agent.runtime.helpers import (
@@ -36,36 +33,6 @@ from loguru import logger
 
 FailureMode = Literal["cancel_downstream", "degrade", "replan"]
 DependencyFailureMode = Literal["inherit", "cancel_downstream", "degrade", "replan"]
-_DEBUG_LOG_PATH = Path("/Users/feihe/Workspace/Synapse/.cursor/debug-caca61.log")
-_DEBUG_SESSION_ID = "caca61"
-
-
-def _emit_debug_log(
-    *,
-    run_id: str,
-    hypothesis_id: str,
-    location: str,
-    message: str,
-    data: dict[str, Any],
-) -> None:
-    payload = {
-        "sessionId": _DEBUG_SESSION_ID,
-        "id": f"log_{uuid4().hex}",
-        "timestamp": int(time.time() * 1000),
-        "runId": run_id,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-    }
-    try:
-        _DEBUG_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with _DEBUG_LOG_PATH.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, ensure_ascii=True) + "\n")
-    except Exception:
-        return
-
-
 @dataclass(frozen=True)
 class TaskAgentConfig:
     """Immutable configuration for a task agent."""
@@ -397,25 +364,6 @@ class TaskAgentRunner:
             )
 
         llm_model = self._config.model or settings.TASK_MODEL
-        message_chars = sum(
-            len(json.dumps(message, ensure_ascii=True)) for message in state.messages
-        )
-        # region agent log
-        _emit_debug_log(
-            run_id="initial",
-            hypothesis_id="H7",
-            location="backend/agent/runtime/task_runner.py:_run_iteration:pre_call",
-            message="Task runner pre-LLM payload stats",
-            data={
-                "model": llm_model,
-                "iteration": state.iteration,
-                "messageCount": len(state.messages),
-                "messageChars": message_chars,
-                "toolCount": len(tools),
-                "systemPromptChars": len(system_prompt),
-            },
-        )
-        # endregion
         try:
 
             async def _on_text_delta(delta: str) -> None:
@@ -432,20 +380,6 @@ class TaskAgentRunner:
                 on_text_delta=_on_text_delta,
             )
         except Exception as exc:
-            # region agent log
-            _emit_debug_log(
-                run_id="initial",
-                hypothesis_id="H7",
-                location="backend/agent/runtime/task_runner.py:_run_iteration:exception",
-                message="Task runner captured LLM exception",
-                data={
-                    "model": llm_model,
-                    "iteration": state.iteration,
-                    "errorType": type(exc).__name__,
-                    "errorText": str(exc)[:500],
-                },
-            )
-            # endregion
             logger.error("llm_call_failed model={} error={}", llm_model, exc)
             return state.mark_error(format_llm_failure(exc))
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -3,12 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-import json
-import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
-from pathlib import Path
-from uuid import uuid4
 
 import uvicorn
 from fastapi import FastAPI
@@ -47,55 +43,12 @@ from api.routes import (
 )
 from config.settings import get_settings
 
-_DEBUG_LOG_PATH = Path("/Users/feihe/Workspace/Synapse/.cursor/debug-caca61.log")
-_DEBUG_SESSION_ID = "caca61"
-
-
-def _emit_debug_log(
-    *,
-    run_id: str,
-    hypothesis_id: str,
-    location: str,
-    message: str,
-    data: dict[str, object],
-) -> None:
-    payload = {
-        "sessionId": _DEBUG_SESSION_ID,
-        "id": f"log_{uuid4().hex}",
-        "timestamp": int(time.time() * 1000),
-        "runId": run_id,
-        "hypothesisId": hypothesis_id,
-        "location": location,
-        "message": message,
-        "data": data,
-    }
-    try:
-        _DEBUG_LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
-        with _DEBUG_LOG_PATH.open("a", encoding="utf-8") as handle:
-            handle.write(json.dumps(payload, ensure_ascii=True) + "\n")
-    except Exception:
-        return
-
-
 def _create_app() -> FastAPI:
     """Create and configure the FastAPI application."""
     from agent.logging import setup_logging
 
     settings = get_settings()
     setup_logging(log_level=settings.LOG_LEVEL)
-    # region agent log
-    _emit_debug_log(
-        run_id="initial",
-        hypothesis_id="H6",
-        location="backend/api/main.py:_create_app",
-        message="Backend process loaded instrumented code",
-        data={
-            "taskModel": settings.TASK_MODEL,
-            "logLevel": settings.LOG_LEVEL,
-        },
-    )
-    # endregion
-
     # Build sandbox provider once at import time
     sandbox_provider, sandbox_pool = _build_sandbox_provider()
 

--- a/backend/api/sse.py
+++ b/backend/api/sse.py
@@ -13,6 +13,8 @@ from loguru import logger
 from api.events import AgentEvent, EventType
 from api.models import ConversationEntry
 
+_SSE_KEEPALIVE_SECONDS = 25.0
+
 
 def _create_queue_subscriber(
     queue: asyncio.Queue[AgentEvent | None],
@@ -56,7 +58,10 @@ async def _event_generator(
         while True:
             # Wait for next event (blocks between turns — that's intentional)
             try:
-                event = await asyncio.wait_for(entry.event_queue.get(), timeout=300.0)
+                event = await asyncio.wait_for(
+                    entry.event_queue.get(),
+                    timeout=_SSE_KEEPALIVE_SECONDS,
+                )
             except asyncio.TimeoutError:
                 # Send keepalive comment to prevent proxy/browser timeout
                 yield ": keepalive\n\n"

--- a/web/src/shared/hooks/use-sse.test.ts
+++ b/web/src/shared/hooks/use-sse.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "@jest/globals";
-import { parseSSEEvent, shouldScheduleReconnect } from "./use-sse";
+import {
+  clearPendingReconnectTimer,
+  parseSSEEvent,
+  shouldScheduleReconnect,
+} from "./use-sse";
 
 describe("shouldScheduleReconnect", () => {
   it("returns false when stopped", () => {
@@ -68,5 +72,25 @@ describe("parseSSEEvent", () => {
     expect(parsed?.type).toBe("skill_setup_failed");
     expect(parsed?.data.name).toBe("docx");
     expect(parsed?.data.phase).toBe("dependencies");
+  });
+});
+
+describe("clearPendingReconnectTimer", () => {
+  it("clears and nulls an active reconnect timer", () => {
+    const timerRef: { current: ReturnType<typeof setTimeout> | null } = {
+      current: setTimeout(() => undefined, 1_000),
+    };
+
+    clearPendingReconnectTimer(timerRef);
+    expect(timerRef.current).toBeNull();
+  });
+
+  it("keeps null timer refs unchanged", () => {
+    const timerRef: { current: ReturnType<typeof setTimeout> | null } = {
+      current: null,
+    };
+
+    clearPendingReconnectTimer(timerRef);
+    expect(timerRef.current).toBeNull();
   });
 });

--- a/web/src/shared/hooks/use-sse.ts
+++ b/web/src/shared/hooks/use-sse.ts
@@ -44,6 +44,15 @@ interface ReconnectGuardInput {
   readonly hasPendingTimer: boolean;
 }
 
+export function clearPendingReconnectTimer(
+  timerRef: { current: ReturnType<typeof setTimeout> | null },
+): void {
+  if (timerRef.current !== null) {
+    clearTimeout(timerRef.current);
+    timerRef.current = null;
+  }
+}
+
 export function shouldScheduleReconnect({
   isStopped,
   retryCount,
@@ -263,10 +272,7 @@ export function useSSE(conversationId: string | null, isLive = true) {
     }
     flushBuffer();
 
-    if (retryTimerRef.current !== null) {
-      clearTimeout(retryTimerRef.current);
-      retryTimerRef.current = null;
-    }
+    clearPendingReconnectTimer(retryTimerRef);
 
     const es = eventSourceRef.current;
     if (es) {
@@ -291,6 +297,7 @@ export function useSSE(conversationId: string | null, isLive = true) {
 
       es.onopen = () => {
         setIsConnected(true);
+        clearPendingReconnectTimer(retryTimerRef);
         retryCountRef.current = 0;
       };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix SSE reconnect race in `useSSE` by clearing any pending manual reconnect timer as soon as the stream opens.
- Reduce backend SSE keepalive interval from 300s to 25s to better survive proxy/browser idle timeouts.
- Remove temporary hardcoded debug instrumentation from backend runtime files.
- Add unit tests for reconnect timer cleanup utility.

## Changes
- `web/src/shared/hooks/use-sse.ts`
  - Added `clearPendingReconnectTimer` helper.
  - Reused helper in cleanup path and `EventSource.onopen`.
- `web/src/shared/hooks/use-sse.test.ts`
  - Added tests for reconnect timer cleanup behavior.
- `backend/api/sse.py`
  - Added `_SSE_KEEPALIVE_SECONDS = 25.0` and used it in `_event_generator` timeout.
- Removed debug logging scaffolding from:
  - `backend/api/main.py`
  - `backend/agent/llm/client.py`
  - `backend/agent/runtime/orchestrator.py`
  - `backend/agent/runtime/task_runner.py`

## Validation
- `make lint` (fails in this environment: `uv: not found`)
- `make test-web` (fails in this environment: `jest: not found`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cdc1cf54-c3aa-4f89-9656-c9b266d8b983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cdc1cf54-c3aa-4f89-9656-c9b266d8b983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

