### PR TITLE
Restrict artifacts to final outputs (explicit paths + filtered auto-detect)

### DIFF
--- a/backend/agent/tools/sandbox/artifact_detection.py
+++ b/backend/agent/tools/sandbox/artifact_detection.py
@@ -18,7 +18,14 @@ from agent.tools.sandbox.constants import ARTIFACT_EXTENSIONS
 # Skills stage resources under ~/skills/, so we scan that in addition
 # to the default /workspace working directory.
 _SKILL_DIR = f"{SANDBOX_HOME_DIR}/skills"
+# Staged skill copies live here; auto-detection must not treat them as user outputs.
+_SKILL_ROOT_PREFIX = f"{_SKILL_DIR}/"
 DEFAULT_SEARCH_ROOTS: tuple[str, ...] = ("/workspace", _SKILL_DIR)
+
+# When the model does not pass output_files, skip plain-text and structured-text
+# outputs from auto-detection — they are usually outlines or build logs, not the
+# final deliverable (e.g. .pptx / .pdf / images).
+_AUTO_DETECT_SKIP_EXTENSIONS = frozenset({".txt", ".md", ".json", ".xml"})
 
 ArtifactSnapshot = dict[str, tuple[int, str]]
 
@@ -140,9 +147,27 @@ async def find_new_output_files(
                 continue
             seen.add(path)
             result.append(path)
-        return result
+        return _filter_auto_detected_paths(result)
     except Exception:
         return []
+
+
+def _filter_auto_detected_paths(paths: list[str]) -> list[str]:
+    """Drop paths that are almost never the user's final deliverable."""
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in paths:
+        path = raw.strip()
+        if not path or path in seen:
+            continue
+        if path.startswith(_SKILL_ROOT_PREFIX):
+            continue
+        _, ext = os.path.splitext(path)
+        if ext.lower() in _AUTO_DETECT_SKIP_EXTENSIONS:
+            continue
+        seen.add(path)
+        out.append(path)
+    return out
 
 
 def build_artifact_paths(
@@ -151,26 +176,42 @@ def build_artifact_paths(
     *,
     exclude_paths: tuple[str, ...] = (),
 ) -> list[str]:
-    """Merge explicit and auto-detected artifact paths.
+    """Resolve artifact paths for sandbox extraction.
 
-    Deduplicates results and excludes any paths whose basename matches
-    *exclude_paths* (e.g. the script file itself).
+    When *explicit* is non-empty (e.g. ``output_files`` from the model), only
+    those paths are used — auto-detection is ignored so intermediate files
+    (another export in the same run, staged skill assets, etc.) are not shown.
+
+    When *explicit* is empty, *auto_found* is used after filtering out staged
+    skill files and common text intermediates.
     """
     exclude_basenames = frozenset(os.path.basename(p) for p in exclude_paths)
 
+    def _passes_excludes(p: str) -> bool:
+        return os.path.basename(p) not in exclude_basenames and p not in exclude_paths
+
+    explicit_clean: list[str] = []
+    seen_exp: set[str] = set()
+    for path in explicit:
+        path = path.strip()
+        if not path or path in seen_exp:
+            continue
+        if not _passes_excludes(path):
+            continue
+        seen_exp.add(path)
+        explicit_clean.append(path)
+
+    if explicit_clean:
+        return explicit_clean
+
     seen: set[str] = set()
     result: list[str] = []
-
-    for path in explicit + auto_found:
-        path = path.strip()
-        if not path:
+    for path in _filter_auto_detected_paths(auto_found):
+        if path in seen:
             continue
-        if os.path.basename(path) in exclude_basenames:
+        if not _passes_excludes(path):
             continue
-        if path in exclude_paths:
-            continue
-        if path not in seen:
-            seen.add(path)
-            result.append(path)
+        seen.add(path)
+        result.append(path)
 
     return result

--- a/backend/agent/tools/sandbox/code_run.py
+++ b/backend/agent/tools/sandbox/code_run.py
@@ -68,10 +68,11 @@ class CodeRun(SandboxTool):
                         "type": "array",
                         "items": {"type": "string"},
                         "description": (
-                            "Absolute paths of OUTPUT files written to disk by "
-                            "the code during execution (e.g. /workspace/report.docx). "
-                            "Do NOT include the script file itself. "
-                            "Only list files the code creates or writes as results."
+                            "Absolute paths of final OUTPUT files only (e.g. "
+                            "/workspace/report.docx). When set, only these paths "
+                            "are registered as artifacts. Do NOT include the "
+                            "script file itself. Omit to use auto-detection under "
+                            "/workspace."
                         ),
                     },
                 },

--- a/backend/agent/tools/sandbox/shell_exec.py
+++ b/backend/agent/tools/sandbox/shell_exec.py
@@ -81,10 +81,10 @@ class ShellExec(SandboxTool):
                         "type": "array",
                         "items": {"type": "string"},
                         "description": (
-                            "Absolute paths of files created or modified by "
-                            "this command that should be saved as downloadable "
-                            "artifacts. Only include files the user would want "
-                            "to view or download."
+                            "Absolute paths of final deliverables only (e.g. the "
+                            "exported .pptx or .pdf). When set, only these paths "
+                            "are registered as artifacts — omit to fall back to "
+                            "auto-detection under /workspace."
                         ),
                     },
                     "id": {

--- a/backend/tests/test_artifact_detection.py
+++ b/backend/tests/test_artifact_detection.py
@@ -62,10 +62,16 @@ class TestFindNewOutputFiles:
         assert "/workspace/data.csv" in result
 
     @pytest.mark.asyncio
-    async def test_finds_files_in_skill_directory(self) -> None:
+    async def test_filters_text_intermediates_from_auto(self) -> None:
+        session = _make_session("/workspace/outline.txt\n/workspace/slides.pptx\n")
+        result = await find_new_output_files(session, "/tmp/marker")
+        assert result == ["/workspace/slides.pptx"]
+
+    @pytest.mark.asyncio
+    async def test_skill_directory_files_not_auto_artifacts(self) -> None:
         session = _make_session("/home/user/skills/pdf/output.pdf\n")
         result = await find_new_output_files(session, "/tmp/marker")
-        assert "/home/user/skills/pdf/output.pdf" in result
+        assert result == []
 
     @pytest.mark.asyncio
     async def test_excludes_specified_paths(self) -> None:
@@ -178,14 +184,15 @@ class TestSnapshotOutputFiles:
 
 
 class TestBuildArtifactPaths:
-    """build_artifact_paths should merge and deduplicate paths."""
+    """build_artifact_paths prefers explicit output_files over auto-detection."""
 
-    def test_merges_explicit_and_auto(self) -> None:
+    def test_explicit_wins_over_auto(self) -> None:
+        """When output_files is set, auto-detected paths are ignored."""
         result = build_artifact_paths(
             ["/workspace/a.pdf"],
             ["/workspace/b.csv"],
         )
-        assert result == ["/workspace/a.pdf", "/workspace/b.csv"]
+        assert result == ["/workspace/a.pdf"]
 
     def test_deduplicates(self) -> None:
         result = build_artifact_paths(
@@ -218,9 +225,25 @@ class TestBuildArtifactPaths:
         result = build_artifact_paths([], [])
         assert result == []
 
-    def test_skill_directory_paths_preserved(self) -> None:
+    def test_skill_directory_auto_paths_dropped(self) -> None:
+        """Staged skill copies must not appear as user artifacts."""
         result = build_artifact_paths(
             [],
             ["/home/user/skills/pdf/output.pdf"],
         )
-        assert result == ["/home/user/skills/pdf/output.pdf"]
+        assert result == []
+
+    def test_explicit_skill_path_allowed(self) -> None:
+        """Model may still name a deliverable under the skill dir via output_files."""
+        result = build_artifact_paths(
+            ["/home/user/skills/pdf/final-deck.pptx"],
+            ["/workspace/other.pptx"],
+        )
+        assert result == ["/home/user/skills/pdf/final-deck.pptx"]
+
+    def test_auto_skips_text_intermediates(self) -> None:
+        result = build_artifact_paths(
+            [],
+            ["/workspace/outline.txt", "/workspace/slides.pptx"],
+        )
+        assert result == ["/workspace/slides.pptx"]

--- a/backend/tests/test_shell_tools.py
+++ b/backend/tests/test_shell_tools.py
@@ -305,8 +305,8 @@ class TestShellWait:
         )
 
     @pytest.mark.asyncio
-    async def test_auto_detection_merges_with_manifest(self) -> None:
-        """Auto-detected artifacts are merged with explicit manifest paths."""
+    async def test_manifest_only_no_merge_with_auto_detect(self) -> None:
+        """Explicit manifest paths win; auto-detected extras are not merged in."""
         session = MockSession(
             {
                 "/pid": ExecResult(stdout="1234"),
@@ -324,10 +324,7 @@ class TestShellWait:
         result = await tool.execute(session=session, id="build", timeout=5)
         assert result.success
         paths = (result.metadata or {}).get("artifact_paths", [])
-        assert "/workspace/report.pdf" in paths
-        assert "/workspace/deck.pptx" in paths
-        # No duplicates
-        assert len(paths) == len(set(paths))
+        assert paths == ["/workspace/report.pdf"]
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The artifacts panel was picking up extra files from auto-detection (e.g. staged skill copies under `~/skills`, or multiple exports when the model passed `output_files` for only one deliverable).

## Changes

- **`build_artifact_paths`**: If `output_files` / shell manifest is non-empty, **only** those paths are used; auto-detected paths are ignored.
- **`find_new_output_files`**: After discovery, drop paths under `~/skills/` (staged skill tree) and common text intermediates (`.txt`, `.md`, `.json`, `.xml`) when relying on auto-detection.
- **Tool schemas** (`shell_exec`, `code_run`): Clarify that `output_files` should list **final** deliverables only and that setting it replaces auto-detection for that call.

## Tests

- Updated `test_artifact_detection` and `test_shell_tools` for the new behavior.
- Ran: `uv run pytest tests/test_artifact_detection.py tests/test_shell_tools.py` (pass). Full `make test` may require env vars (`ANTHROPIC_API_KEY`, etc.) during collection in this environment.

## Notes

- `file_write` with `is_artifact: true` still registers a file even if it is not the "final" binary; the model should use `is_artifact: false` for intermediates (already supported).
- If the model omits `output_files` and produces **only** a `.csv` / `.json` deliverable, auto-detection still applies; `.json` is now skipped from **auto** paths only (explicit `output_files` still works).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ee9bd1-ab1e-4ddd-b7d8-95e6016a8bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ee9bd1-ab1e-4ddd-b7d8-95e6016a8bdf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

