### PR TITLE
Stabilize streaming chat rendering (markdown + row keys)

### DIFF
--- a/web/jest.config.cjs
+++ b/web/jest.config.cjs
@@ -8,6 +8,12 @@ const customJestConfig = {
   testEnvironment: "node",
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
+    // ESM-only markdown stack — stub in Jest (real parsing is covered in build / browser).
+    "^react-markdown$": "<rootDir>/src/test/mocks/react-markdown.tsx",
+    "^remark-gfm$": "<rootDir>/src/test/mocks/unified-noop-plugin.ts",
+    "^remark-math$": "<rootDir>/src/test/mocks/unified-noop-plugin.ts",
+    "^rehype-katex$": "<rootDir>/src/test/mocks/unified-noop-plugin.ts",
+    "^rehype-highlight$": "<rootDir>/src/test/mocks/unified-noop-plugin.ts",
   },
   testMatch: ["**/*.test.ts", "**/*.test.tsx"],
 };

--- a/web/src/features/conversation/components/ConversationWorkspace.tsx
+++ b/web/src/features/conversation/components/ConversationWorkspace.tsx
@@ -494,9 +494,12 @@ export function ConversationWorkspace({
                         currentThinkingEntries.length > 0;
                       const embeddedPlanSteps =
                         i === planMessageIndex && effectivePlanSteps.length > 0 ? effectivePlanSteps : [];
-                      // Use a stable key that doesn't change during streaming.
-                      // For messages with IDs, use the ID. For others, use role + timestamp + content hash.
-                      const messageKey = msg.messageId ?? `${msg.role}-${msg.timestamp}-${msg.content.slice(0, 20)}`;
+                      // Stable React keys: never key assistant rows on `content` while
+                      // they stream (keys would churn every token → remount + flash).
+                      const messageKey =
+                        msg.role === "assistant" && isStreamingThis && msg.turnId
+                          ? `${msg.turnId}:assistant-stream`
+                          : msg.messageId ?? `${msg.role}-${msg.timestamp}-${msg.content.slice(0, 20)}`;
 
                       return (
                         <MessageRow

--- a/web/src/shared/components/MarkdownRenderer.test.tsx
+++ b/web/src/shared/components/MarkdownRenderer.test.tsx
@@ -62,10 +62,26 @@ describe("MarkdownRenderer", () => {
     expect(html).toContain('data-testid="parsed-markdown"');
   });
 
-  it("renders stable markdown blocks while keeping the trailing paragraph lightweight during streaming", () => {
+  it("defaults isStreaming to lightweight rendering (no ReactMarkdown thrash)", () => {
     const html = renderToStaticMarkup(
       <MarkdownRenderer
         content={"# Title\n\n- one\n- two\n\nTrailing paragraph"}
+        isStreaming
+      />,
+    );
+
+    expect(html).not.toContain('data-testid="parsed-markdown"');
+    expect(html).toContain("markdown-streaming-tail");
+    expect(html).toContain(">Title</span>");
+    expect(html).toContain(">•</span>");
+    expect(html).toContain("Trailing paragraph");
+  });
+
+  it("renders stable markdown blocks while keeping the trailing paragraph lightweight in hybrid mode", () => {
+    const html = renderToStaticMarkup(
+      <MarkdownRenderer
+        content={"# Title\n\n- one\n- two\n\nTrailing paragraph"}
+        mode="streaming-hybrid"
         isStreaming
       />,
     );
@@ -77,10 +93,11 @@ describe("MarkdownRenderer", () => {
     expect(html).toContain("Trailing paragraph");
   });
 
-  it("keeps an unmatched fenced code block entirely in the lightweight tail", () => {
+  it("keeps an unmatched fenced code block entirely in the lightweight tail (hybrid split)", () => {
     const html = renderToStaticMarkup(
       <MarkdownRenderer
         content={"Intro\n\n```ts\nconst x = 1;"}
+        mode="streaming-hybrid"
         isStreaming
       />,
     );
@@ -92,10 +109,11 @@ describe("MarkdownRenderer", () => {
     expect(html).toContain("const x = 1;");
   });
 
-  it("keeps a trailing list block lightweight until the stream finishes the block", () => {
+  it("keeps a trailing list block lightweight until the stream finishes the block (hybrid)", () => {
     const html = renderToStaticMarkup(
       <MarkdownRenderer
         content={"Intro\n\n- one\n- two"}
+        mode="streaming-hybrid"
         isStreaming
       />,
     );
@@ -123,10 +141,11 @@ describe("MarkdownRenderer", () => {
     expect(html).toContain("markdown-streaming-tail");
   });
 
-  it("keeps an unfinished chunk-split link as raw lightweight tail text until it closes", () => {
+  it("keeps an unfinished chunk-split link as raw lightweight tail text until it closes (hybrid)", () => {
     const html = renderToStaticMarkup(
       <MarkdownRenderer
         content={"Visit [docs](https://example"}
+        mode="streaming-hybrid"
         isStreaming
       />,
     );
@@ -138,10 +157,11 @@ describe("MarkdownRenderer", () => {
     expect(html).not.toContain(">docs</a>");
   });
 
-  it("promotes the paragraph into parsed markdown once the block is closed", () => {
+  it("promotes the paragraph into parsed markdown once the block is closed (hybrid)", () => {
     const html = renderToStaticMarkup(
       <MarkdownRenderer
         content={"Visit [docs](https://example.com) and **pay attention**.\n\n"}
+        mode="streaming-hybrid"
         isStreaming
       />,
     );
@@ -212,10 +232,11 @@ describe("MarkdownRenderer", () => {
     expect(html).toContain("你好，世界");
   });
 
-  it("promotes a closed CJK paragraph into parsed markdown", () => {
+  it("promotes a closed CJK paragraph into parsed markdown (hybrid)", () => {
     const html = renderToStaticMarkup(
       <MarkdownRenderer
         content={"你好，世界\n\n"}
+        mode="streaming-hybrid"
         isStreaming
       />,
     );

--- a/web/src/shared/components/markdown-render-strategy.test.ts
+++ b/web/src/shared/components/markdown-render-strategy.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "@jest/globals";
 import { getMarkdownRenderStrategy, splitStreamingMarkdown } from "./markdown-render-strategy";
 
 describe("markdown render strategy", () => {
-  it("uses the hybrid streaming strategy for in-flight content", () => {
-    expect(getMarkdownRenderStrategy(true)).toBe("streaming-hybrid");
+  it("uses the lightweight streaming strategy for in-flight content", () => {
+    expect(getMarkdownRenderStrategy(true)).toBe("streaming-light");
   });
 
   it("uses the settled strategy after streaming ends", () => {

--- a/web/src/shared/components/markdown-render-strategy.ts
+++ b/web/src/shared/components/markdown-render-strategy.ts
@@ -1,7 +1,10 @@
 export type MarkdownRenderStrategy = "streaming-light" | "streaming-hybrid" | "settled";
 
 export function getMarkdownRenderStrategy(isStreaming?: boolean): MarkdownRenderStrategy {
-  return isStreaming ? "streaming-hybrid" : "settled";
+  // Full `streaming-hybrid` (ReactMarkdown + tail) re-parses the stable prefix on
+  // every token and can thrash layout. Prefer the lightweight path for in-flight
+  // text; callers can still force `mode="streaming-hybrid"` when needed.
+  return isStreaming ? "streaming-light" : "settled";
 }
 
 export interface StreamingMarkdownSegments {

--- a/web/src/shared/components/ui/tooltip.tsx
+++ b/web/src/shared/components/ui/tooltip.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { Tooltip as TooltipPrimitive } from "radix-ui"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/shared/lib/utils"
 

--- a/web/src/test/mocks/react-markdown.tsx
+++ b/web/src/test/mocks/react-markdown.tsx
@@ -1,0 +1,8 @@
+import type { ReactNode } from "react";
+
+/**
+ * Minimal stub for Jest — real markdown is exercised via the app / integration.
+ */
+export default function ReactMarkdown({ children }: { children?: string }): ReactNode {
+  return <div data-testid="parsed-markdown">{children}</div>;
+}

--- a/web/src/test/mocks/unified-noop-plugin.ts
+++ b/web/src/test/mocks/unified-noop-plugin.ts
@@ -1,0 +1,4 @@
+/** Placeholder unified/remark/rehype plugin for Jest (real plugins are ESM-only). */
+export default function noopPlugin(): undefined {
+  return undefined;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses visible glitches during assistant streaming: unstable message row keys, heavy markdown re-parsing each token, and a small tooltip import cleanup.

## Changes

- **Streaming markdown**: `getMarkdownRenderStrategy(true)` now defaults to `streaming-light` instead of `streaming-hybrid`, so the UI does not re-run `ReactMarkdown` on the full stable prefix on every `text_delta`. Full prose + math/highlight still applies once `isStreaming` is false. Hybrid remains available via `MarkdownRenderer` `mode="streaming-hybrid"`.
- **Stable React keys**: While the last assistant row is streaming and has a `turnId`, the list key is `${turnId}:assistant-stream` so the row is not remounted when `messageId` changes at finalize (which caused flashes / order jumps).
- **Tooltip import**: `tooltip.tsx` imports primitives from `@radix-ui/react-tooltip` instead of the `radix-ui` barrel.
- **Jest**: Map ESM-only `react-markdown` / remark / rehype packages to small stubs so suites that touch `MarkdownRenderer` do not crash; `MarkdownRenderer` tests updated accordingly.

## Testing

- `npx jest` on updated markdown tests passes.
- Full `make test-web` still reports unrelated failures in `message-identity.test.ts` and `HomeScreen.test.tsx` (pre-existing vs this branch).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ae9db22d-b4e7-438e-b95a-5ee870aba59d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ae9db22d-b4e7-438e-b95a-5ee870aba59d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

