### PR TITLE
Improve streaming markdown default render strategy

### DIFF
--- a/web/src/shared/components/MarkdownRenderer.test.tsx
+++ b/web/src/shared/components/MarkdownRenderer.test.tsx
@@ -62,7 +62,7 @@ describe("MarkdownRenderer", () => {
     expect(html).toContain('data-testid="parsed-markdown"');
   });
 
-  it("defaults isStreaming to lightweight rendering (no ReactMarkdown thrash)", () => {
+  it("defaults isStreaming to hybrid rendering so stable markdown blocks stay parsed", () => {
     const html = renderToStaticMarkup(
       <MarkdownRenderer
         content={"# Title\n\n- one\n- two\n\nTrailing paragraph"}
@@ -70,10 +70,10 @@ describe("MarkdownRenderer", () => {
       />,
     );
 
-    expect(html).not.toContain('data-testid="parsed-markdown"');
+    expect(html).toContain('data-testid="parsed-markdown"');
     expect(html).toContain("markdown-streaming-tail");
-    expect(html).toContain(">Title</span>");
-    expect(html).toContain(">•</span>");
+    expect(html).toContain("# Title");
+    expect(html).toContain("- one");
     expect(html).toContain("Trailing paragraph");
   });
 

--- a/web/src/shared/components/markdown-render-strategy.ts
+++ b/web/src/shared/components/markdown-render-strategy.ts
@@ -1,10 +1,10 @@
 export type MarkdownRenderStrategy = "streaming-light" | "streaming-hybrid" | "settled";
 
 export function getMarkdownRenderStrategy(isStreaming?: boolean): MarkdownRenderStrategy {
-  // Full `streaming-hybrid` (ReactMarkdown + tail) re-parses the stable prefix on
-  // every token and can thrash layout. Prefer the lightweight path for in-flight
-  // text; callers can still force `mode="streaming-hybrid"` when needed.
-  return isStreaming ? "streaming-light" : "settled";
+  // Default to hybrid rendering while streaming so complete markdown blocks
+  // (headings, lists, fenced code, links) stay accurate in live view while
+  // keeping only the unfinished tail lightweight.
+  return isStreaming ? "streaming-hybrid" : "settled";
 }
 
 export interface StreamingMarkdownSegments {


### PR DESCRIPTION
### Motivation
- Live assistant streaming produced incomplete or incorrect rendered markdown (headings, lists, fenced code, links) that only corrected after a refresh, so default rendering should preserve stable blocks while keeping the trailing unfinished text lightweight.

### Description
- Change default behaviour of `getMarkdownRenderStrategy` to return `"streaming-hybrid"` when `isStreaming` so stable markdown blocks are parsed during streaming (`web/src/shared/components/markdown-render-strategy.ts`).
- Update `MarkdownRenderer` tests to reflect the new default behaviour and assert that stable content is parsed while a lightweight tail is used (`web/src/shared/components/MarkdownRenderer.test.tsx`).
- Adjusted test description and assertions to expect `data-testid="parsed-markdown"` in the streaming default case.

### Testing
- Ran the updated `MarkdownRenderer` unit tests via `npm test -- src/shared/components/MarkdownRenderer.test.tsx`, which could not execute in this environment because the test runner is unavailable (`jest: not found`), so automated test execution failed here.
- No other automated test suites were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e814ba74c08324966a7f6a084645ec)