### PR TITLE
Simplify MCP add/edit dialog by removing URL field

### DIFF
--- a/web/src/features/mcp/components/MCPAddServerDialog.tsx
+++ b/web/src/features/mcp/components/MCPAddServerDialog.tsx
@@ -21,7 +21,6 @@ interface MCPAddServerDialogProps {
   readonly onFormSchemaChange: (value: string) => void;
   readonly formName: string;
   readonly formTransport: MCPTransport;
-  readonly formUrl: string;
   readonly headerCount: number;
   readonly submitting: boolean;
   readonly mode?: "add" | "edit";
@@ -40,7 +39,6 @@ export function MCPAddServerDialog({
   onFormSchemaChange,
   formName,
   formTransport,
-  formUrl,
   headerCount,
   submitting,
   mode = "add",
@@ -89,7 +87,6 @@ export function MCPAddServerDialog({
           onFormSchemaChange={onFormSchemaChange}
           formName={formName}
           formTransport={formTransport}
-          formUrl={formUrl}
           headerCount={headerCount}
           submitting={submitting}
           title={title}

--- a/web/src/features/mcp/components/MCPDialog.tsx
+++ b/web/src/features/mcp/components/MCPDialog.tsx
@@ -75,7 +75,6 @@ export function MCPDialog({
     setFormSchema,
     formName,
     formTransport,
-    formUrl,
     formHeaders,
     serverToEdit,
     submitting,
@@ -290,7 +289,6 @@ export function MCPDialog({
         onFormSchemaChange={setFormSchema}
         formName={formName}
         formTransport={formTransport}
-        formUrl={formUrl}
         headerCount={Object.keys(formHeaders).length}
         submitting={submitting}
         mode={serverToEdit ? "edit" : "add"}

--- a/web/src/features/mcp/components/MCPPage.tsx
+++ b/web/src/features/mcp/components/MCPPage.tsx
@@ -66,7 +66,6 @@ export function MCPPage() {
     setFormSchema,
     formName,
     formTransport,
-    formUrl,
     formHeaders,
     serverToEdit,
     submitting,
@@ -282,7 +281,6 @@ export function MCPPage() {
         onFormSchemaChange={setFormSchema}
         formName={formName}
         formTransport={formTransport}
-        formUrl={formUrl}
         headerCount={Object.keys(formHeaders).length}
         submitting={submitting}
         mode={serverToEdit ? "edit" : "add"}

--- a/web/src/features/mcp/components/MCPServerForm.tsx
+++ b/web/src/features/mcp/components/MCPServerForm.tsx
@@ -24,7 +24,6 @@ interface MCPServerFormProps {
   readonly onFormSchemaChange: (value: string) => void;
   readonly formName: string;
   readonly formTransport: MCPTransport;
-  readonly formUrl: string;
   readonly headerCount: number;
   readonly submitting: boolean;
   readonly title: string;
@@ -43,7 +42,6 @@ export function MCPServerForm({
   onFormSchemaChange,
   formName,
   formTransport,
-  formUrl,
   headerCount,
   submitting,
   title,
@@ -165,22 +163,10 @@ export function MCPServerForm({
               {formTransport}
             </dd>
           </div>
-
-          <div className="min-w-0 rounded-md border border-border bg-background px-3 py-2 sm:col-span-2">
-            <dt className="label-mono text-muted-foreground-dim">
-              {t("mcp.urlLabel")}
-            </dt>
-            <dd className="mt-1 truncate font-mono text-sm text-foreground">
-              {formUrl.trim() || t("mcp.urlPlaceholder")}
-            </dd>
-          </div>
         </dl>
       </section>
 
       <div className="flex flex-col-reverse gap-2 border-t border-border pt-4 sm:flex-row sm:items-center sm:justify-between">
-        <p className="font-mono text-micro text-muted-foreground-dim">
-          {formUrl.trim() || t("mcp.urlPlaceholder")}
-        </p>
         <div className="flex justify-end gap-2">
           <Button
             variant="ghost"


### PR DESCRIPTION
### Motivation
- The MCP add/edit form should be driven entirely by the JSON schema textarea (name/transport parsed from the schema), so the separate URL preview field is redundant and should be removed.

### Description
- Removed the URL summary row and footer URL preview from the MCP server form so the UI relies on the JSON schema textarea for configuration display.
- Dropped the now-unused `formUrl` prop from `MCPServerForm`, and removed plumbing that passed `formUrl` through `MCPAddServerDialog`, `MCPDialog`, and `MCPPage`.
- Kept existing schema parsing and header/transport display behavior intact so `applySchema`/`buildMCPServerConfigFromJson` continue to populate name, transport, and headers.

### Testing
- Ran the frontend typecheck with `npm run typecheck`, which failed in this environment due to missing frontend dependencies/type declarations and broad module-resolution errors unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac0eb0ef4832497c51609dccfbcd6)