### PR TITLE
refactor(runtime): unify agent-loop harness across the three ReAct loops

### DIFF
--- a/backend/agent/context/compaction_step.py
+++ b/backend/agent/context/compaction_step.py
@@ -1,0 +1,107 @@
+"""Shared context-compaction step for agent runtimes.
+
+The single-agent orchestrator, planner, and task-agent runner all compact
+message history the same way before an LLM call: ask the observer whether to
+compact, run hooks, compact, emit ``CONTEXT_COMPACTED``, and swap in the
+compacted messages. This module owns that sequence once.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from agent.context.compaction import (
+    Observer,
+    compaction_summary_for_persistence,
+)
+from agent.context.profiles import CompactionProfile
+from agent.runtime.hooks import (
+    ContextCompactionContext,
+    ContextCompactionResult,
+    ConversationHooks,
+)
+from api.events import EventEmitter, EventType
+
+
+@dataclass(frozen=True)
+class CompactionStep:
+    """Run the observer-driven compaction sequence for one runtime.
+
+    Web and planner runtimes wire in conversation hooks and a ``conversation``
+    summary scope; the task-agent runner uses a ``task_agent`` scope, attaches
+    its ``agent_id``, and a metrics callback instead of hooks.
+    """
+
+    observer: Observer
+    profile: CompactionProfile
+    emitter: EventEmitter
+    summary_scope: str
+    conversation_id: str | None = None
+    user_id: Any | None = None
+    persistent_store: Any | None = None
+    hooks: ConversationHooks | None = None
+    agent_id: str | None = None
+    emit_iteration: bool = True
+    on_compacted: Callable[[], None] | None = None
+
+    async def maybe_compact(
+        self,
+        messages: tuple[dict[str, Any], ...],
+        effective_prompt: str,
+        *,
+        iteration: int | None = None,
+    ) -> tuple[tuple[dict[str, Any], ...], bool]:
+        """Compact *messages* when the observer asks for it.
+
+        Returns the (possibly compacted) messages and whether compaction ran.
+        """
+        if not self.observer.should_compact(messages, effective_prompt):
+            return messages, False
+
+        context = ContextCompactionContext(
+            conversation_id=self.conversation_id,
+            user_id=self.user_id,
+            messages=messages,
+            effective_prompt=effective_prompt,
+            profile_name=self.profile.name,
+            metadata={
+                "memory_flush": self.profile.memory_flush,
+                "persistent_store": self.persistent_store,
+            },
+        )
+        if self.hooks is not None:
+            await self.hooks.before_context_compaction(context)
+
+        compacted = await self.observer.compact(messages, effective_prompt)
+        summary_text = compaction_summary_for_persistence(compacted)
+
+        payload: dict[str, Any] = {
+            "original_messages": len(messages),
+            "compacted_messages": len(compacted),
+            "summary_text": summary_text,
+            "summary_scope": self.summary_scope,
+            "compaction_profile": self.profile.name,
+        }
+        if self.agent_id is not None:
+            payload["agent_id"] = self.agent_id
+
+        emit_kwargs: dict[str, Any] = {}
+        if self.emit_iteration and iteration is not None:
+            emit_kwargs["iteration"] = iteration
+        await self.emitter.emit(EventType.CONTEXT_COMPACTED, payload, **emit_kwargs)
+
+        if self.hooks is not None:
+            await self.hooks.after_context_compaction(
+                context,
+                ContextCompactionResult(
+                    original_message_count=len(messages),
+                    compacted_messages=compacted,
+                    summary_text=summary_text,
+                ),
+            )
+        if self.on_compacted is not None:
+            self.on_compacted()
+
+        return compacted, True

--- a/backend/agent/runtime/engine.py
+++ b/backend/agent/runtime/engine.py
@@ -10,6 +10,7 @@ parts that genuinely differ (model, event surface, completion rules, metrics).
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any
 
@@ -49,16 +50,18 @@ class LoopConfig:
     debug_logging: bool = False
 
 
-class LoopPolicy:
+class LoopPolicy(ABC):
     """Hooks describing how a runtime diverges from the shared loop.
 
     Runtime classes subclass this (alongside their own bases) and override only
-    the hooks they need; every hook has a behavior-neutral default.
+    the hooks they need; every hook has a behavior-neutral default. The single
+    required override is :attr:`loop_config`.
     """
 
     @property
+    @abstractmethod
     def loop_config(self) -> LoopConfig:
-        raise NotImplementedError
+        """Per-iteration knobs (model, event surface, limits) for this runtime."""
 
     def loop_cancel_requested(self) -> bool:
         """Whether the turn should stop before the next iteration."""
@@ -117,6 +120,9 @@ class AgentLoop:
         self._compaction_step = compaction_step
         self._skill_controller = skill_controller
         self._policy = policy
+        # Per-turn scratch for a skill activation requested mid-iteration. Safe
+        # as instance state because each runtime owns one AgentLoop and serializes
+        # run_turn (run-lock or single-shot task); it is reset at run_turn entry.
         self._pending_mid_turn_update: Any | None = None
 
     async def run_turn(

--- a/backend/agent/runtime/engine.py
+++ b/backend/agent/runtime/engine.py
@@ -1,0 +1,354 @@
+"""Shared ReAct loop engine for agent runtimes.
+
+The single-agent orchestrator, planner, and task-agent runner share one
+iteration mechanism: compact, (optionally) announce the iteration, guard the
+iteration ceiling, stream an LLM response, apply it, run tool calls (handling
+mid-turn skill activation), and check for completion. :class:`AgentLoop` owns
+that mechanism once; each runtime supplies a :class:`LoopPolicy` describing the
+parts that genuinely differ (model, event surface, completion rules, metrics).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from agent.llm.client import (
+    AnthropicClient,
+    LLMResponse,
+    SystemPrompt,
+    format_llm_failure,
+)
+from agent.context.compaction_step import CompactionStep
+from agent.runtime.helpers import apply_response_to_state, process_tool_calls
+from agent.runtime.message_chain import collect_message_chain_warnings
+from agent.runtime.prompting import PromptAssembly
+from agent.runtime.skill_activation import SkillActivationController
+from agent.tools.executor import ToolExecutor
+from api.events import EventEmitter, EventType
+
+if TYPE_CHECKING:
+    from agent.runtime.orchestrator import AgentState
+
+
+@dataclass(frozen=True)
+class LoopConfig:
+    """Per-runtime knobs for the shared loop that are plain values."""
+
+    max_iterations: int
+    model: str | None = None
+    thinking_budget: int = 0
+    emit_thinking: bool = False
+    emit_iteration_start: bool = True
+    emit_llm_response: bool = True
+    validate_message_chain: bool = False
+    agent_id: str | None = None
+    debug_label: str = "agent"
+    debug_logging: bool = False
+
+
+class LoopPolicy:
+    """Hooks describing how a runtime diverges from the shared loop.
+
+    Runtime classes subclass this (alongside their own bases) and override only
+    the hooks they need; every hook has a behavior-neutral default.
+    """
+
+    @property
+    def loop_config(self) -> LoopConfig:
+        raise NotImplementedError
+
+    def loop_cancel_requested(self) -> bool:
+        """Whether the turn should stop before the next iteration."""
+        return False
+
+    def loop_stop_processing(self) -> bool:
+        """``stop_check`` handed to :func:`process_tool_calls`."""
+        return False
+
+    def loop_iteration_prompt(self, assembly: PromptAssembly) -> PromptAssembly:
+        """Adjust the prompt assembly for a single iteration (e.g. nudges)."""
+        return assembly
+
+    def loop_on_iteration_begin(self, state: AgentState) -> None:
+        """Called after the iteration counter is incremented."""
+
+    async def loop_on_llm_usage(self, response: LLMResponse) -> None:
+        """Record token usage for a streamed response (metrics)."""
+
+    async def loop_on_no_tool_calls(
+        self, state: AgentState, response: LLMResponse
+    ) -> AgentState:
+        """Decide completion when the model returns no tool calls."""
+        return state.mark_completed()
+
+    async def loop_on_tools_processed(
+        self,
+        state: AgentState,
+        response: LLMResponse,
+        tool_result: Any,
+    ) -> AgentState:
+        """React to a completed tool batch (artifacts, metrics, loop guard)."""
+        return state
+
+    async def loop_on_task_complete(self, state: AgentState) -> AgentState | None:
+        """Return a terminal state when a completion signal fired, else None."""
+        return None
+
+
+class AgentLoop:
+    """Drive the ReAct loop for one runtime, delegating divergences to a policy."""
+
+    def __init__(
+        self,
+        *,
+        client: AnthropicClient,
+        emitter: EventEmitter,
+        executor: ToolExecutor,
+        compaction_step: CompactionStep,
+        skill_controller: SkillActivationController,
+        policy: LoopPolicy,
+    ) -> None:
+        self._client = client
+        self._emitter = emitter
+        self._executor = executor
+        self._compaction_step = compaction_step
+        self._skill_controller = skill_controller
+        self._policy = policy
+        self._pending_mid_turn_update: Any | None = None
+
+    async def run_turn(
+        self,
+        *,
+        state: AgentState,
+        prompt_assembly: PromptAssembly,
+        tools: list[dict[str, Any]],
+        cache_prompt: bool,
+    ) -> AgentState:
+        """Run the ReAct loop to completion and return the terminal state."""
+        self._pending_mid_turn_update = None
+        while not state.completed and state.error is None:
+            if self._policy.loop_cancel_requested():
+                break
+            state = state.increment_iteration()
+            self._policy.loop_on_iteration_begin(state)
+            iter_assembly = self._policy.loop_iteration_prompt(prompt_assembly)
+            state = await self._run_iteration(
+                state,
+                tools,
+                iter_assembly.system_with_cache_control(cache_prompt),
+                iter_assembly.rendered,
+                cache_prompt,
+            )
+
+            update = self._pending_mid_turn_update
+            self._pending_mid_turn_update = None
+            if update is None:
+                update = await self._skill_controller.check_mid_turn_from_messages(
+                    list(state.messages),
+                    cache_prompt=cache_prompt,
+                )
+            if update is not None:
+                prompt_assembly = update.prompt_assembly
+                tools = update.tools
+        return state
+
+    async def _run_iteration(
+        self,
+        state: AgentState,
+        tools: list[dict[str, Any]],
+        system_prompt: SystemPrompt,
+        system_prompt_text: str,
+        cache_prompt: bool,
+    ) -> AgentState:
+        config = self._policy.loop_config
+
+        if config.validate_message_chain:
+            for warning in collect_message_chain_warnings(state.messages):
+                logger.warning("message_chain_warning detail={}", warning)
+
+        compacted, did_compact = await self._compaction_step.maybe_compact(
+            state.messages,
+            system_prompt_text,
+            iteration=state.iteration,
+        )
+        if did_compact:
+            logger.debug("compacting_message_history")
+            state = replace(state, messages=compacted)
+
+        logger.info("iteration={}/{}", state.iteration, config.max_iterations)
+
+        if config.emit_iteration_start:
+            await self._emitter.emit(
+                EventType.ITERATION_START,
+                {"iteration": state.iteration},
+                iteration=state.iteration,
+            )
+
+        if state.iteration > config.max_iterations:
+            logger.warning("max_iterations_exceeded limit={}", config.max_iterations)
+            return state.mark_error(
+                f"Exceeded maximum iterations ({config.max_iterations})",
+            )
+
+        response, llm_error = await self._stream_llm(state, tools, system_prompt)
+        if llm_error is not None:
+            return state.mark_error(llm_error)
+
+        await self._policy.loop_on_llm_usage(response)
+        if config.emit_llm_response:
+            await self._emit_llm_response(state, response)
+
+        state = apply_response_to_state(state, response)
+
+        if not response.tool_calls:
+            return await self._policy.loop_on_no_tool_calls(state, response)
+
+        async def _post_tool_callback(tc: Any, result: Any) -> None:
+            if not result.success:
+                return
+            skill_name = self._skill_controller.requested_skill_name(tc.name, tc.input)
+            if skill_name is None:
+                return
+            updated = await self._skill_controller.apply_mid_turn(
+                skill_name,
+                tool_id=tc.id,
+                messages=list(state.messages),
+                cache_prompt=cache_prompt,
+            )
+            if updated is not None:
+                self._pending_mid_turn_update = updated
+
+        try:
+            tool_result = await process_tool_calls(
+                state=state,
+                tool_calls=response.tool_calls,
+                executor=self._executor,
+                emitter=self._emitter,
+                agent_id=config.agent_id,
+                stop_check=self._policy.loop_stop_processing,
+                cancel_check=self._policy.loop_cancel_requested,
+                post_tool_callback=_post_tool_callback,
+            )
+        except Exception as exc:
+            return state.mark_error(str(exc))
+
+        state = await self._policy.loop_on_tools_processed(state, response, tool_result)
+
+        completed = await self._policy.loop_on_task_complete(state)
+        if completed is not None:
+            return completed
+        return state
+
+    async def _stream_llm(
+        self,
+        state: AgentState,
+        tools: list[dict[str, Any]],
+        system_prompt: SystemPrompt,
+    ) -> tuple[LLMResponse | None, str | None]:
+        config = self._policy.loop_config
+        llm_model = config.model or getattr(self._client, "default_model", "<unknown>")
+        debug_logging = config.debug_logging
+        thinking_emitted = False
+
+        async def _on_text_delta(delta: str) -> None:
+            payload: dict[str, Any] = {"delta": delta}
+            if config.agent_id is not None:
+                payload["agent_id"] = config.agent_id
+            await self._emitter.emit(
+                EventType.TEXT_DELTA, payload, iteration=state.iteration
+            )
+
+        async def _on_thinking_ready(thinking: str) -> None:
+            nonlocal thinking_emitted
+            if not thinking:
+                return
+            thinking_emitted = True
+            await self._emitter.emit(
+                EventType.THINKING,
+                {"thinking": thinking},
+                iteration=state.iteration,
+            )
+
+        stream_kwargs: dict[str, Any] = {
+            "system": system_prompt,
+            "messages": list(state.messages),
+            "tools": tools if tools else None,
+            "on_text_delta": _on_text_delta,
+        }
+        if config.model is not None:
+            stream_kwargs["model"] = config.model
+        if config.emit_thinking:
+            stream_kwargs["thinking_budget"] = config.thinking_budget
+
+        if debug_logging:
+            logger.debug(
+                "{}_llm_call model={} iteration={} messages={} tools={}",
+                config.debug_label,
+                llm_model,
+                state.iteration,
+                len(state.messages),
+                len(tools),
+            )
+
+        try:
+            if config.emit_thinking:
+                try:
+                    response = await self._client.create_message_stream(
+                        **stream_kwargs,
+                        on_thinking_ready=_on_thinking_ready,
+                    )
+                except TypeError as exc:
+                    if "on_thinking_ready" not in str(exc):
+                        raise
+                    response = await self._client.create_message_stream(**stream_kwargs)
+            else:
+                response = await self._client.create_message_stream(**stream_kwargs)
+        except Exception as exc:
+            if debug_logging:
+                logger.debug(
+                    "{}_llm_exception model={} iteration={} error_type={}",
+                    config.debug_label,
+                    llm_model,
+                    state.iteration,
+                    type(exc).__name__,
+                )
+            logger.error("llm_call_failed model={} error={}", llm_model, exc)
+            return None, format_llm_failure(exc)
+
+        if config.emit_thinking and response.thinking and not thinking_emitted:
+            await self._emitter.emit(
+                EventType.THINKING,
+                {"thinking": response.thinking},
+                iteration=state.iteration,
+            )
+
+        return response, None
+
+    async def _emit_llm_response(
+        self,
+        state: AgentState,
+        response: LLMResponse,
+    ) -> None:
+        logger.info(
+            "llm_response model={} stop_reason={} tool_calls={} "
+            "input_tokens={} output_tokens={}",
+            self._policy.loop_config.model
+            or getattr(self._client, "default_model", "<unknown>"),
+            response.stop_reason,
+            len(response.tool_calls),
+            response.usage.input_tokens,
+            response.usage.output_tokens,
+        )
+        await self._emitter.emit(
+            EventType.LLM_RESPONSE,
+            {
+                "text": response.text,
+                "tool_call_count": len(response.tool_calls),
+                "stop_reason": response.stop_reason,
+                "usage": response.usage,
+            },
+            iteration=state.iteration,
+        )

--- a/backend/agent/runtime/helpers.py
+++ b/backend/agent/runtime/helpers.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, Awaitable, Callable
 
 from loguru import logger
 
-from agent.llm.client import LLMResponse, ToolCall
+from agent.llm.client import LLMResponse, ToolCall, is_content_policy_error
 from agent.tools.base import ToolResult
 from agent.tools.executor import ToolExecutor
 from api.events import EventEmitter, EventType
@@ -16,6 +16,59 @@ from config.settings import get_settings
 
 if TYPE_CHECKING:
     from agent.runtime.orchestrator import AgentState
+
+
+def classify_turn_error(error: str) -> tuple[str, bool]:
+    """Map a terminal error message to an event ``(code, retryable)`` pair."""
+    retryable = "LLM call failed" in error
+    code = "llm_error" if retryable else "agent_error"
+    if is_content_policy_error(error):
+        return "content_policy", False
+    if "maximum iterations" in error.lower():
+        return "max_iterations", False
+    return code, retryable
+
+
+async def finalize_conversation_turn(
+    *,
+    state: AgentState,
+    cancel_event: asyncio.Event,
+    current_turn_messages: tuple[dict[str, Any], ...],
+    base_messages: tuple[dict[str, Any], ...],
+    emitter: EventEmitter,
+    artifact_ids: list[str],
+) -> tuple[str, AgentState]:
+    """Emit the terminal turn event and return ``(result_text, new_state)``.
+
+    Shared by the conversation-style runtimes (web orchestrator and planner),
+    which handle cancellation, error, and completion identically. The returned
+    state replaces the caller's state (only the cancel path rewinds it).
+    """
+    if cancel_event.is_set():
+        cancel_event.clear()
+        final_text = extract_final_text_from_messages(current_turn_messages)
+        await emitter.emit(EventType.TURN_CANCELLED, {"result": final_text})
+        return final_text, replace(
+            state,
+            messages=base_messages,
+            completed=False,
+            error=None,
+        )
+
+    if state.error:
+        code, retryable = classify_turn_error(state.error)
+        await emitter.emit(
+            EventType.TASK_ERROR,
+            {"error": state.error, "code": code, "retryable": retryable},
+        )
+        return f"Error: {state.error}", state
+
+    final_text = extract_final_text(state)
+    await emitter.emit(
+        EventType.TURN_COMPLETE,
+        {"result": final_text, "artifact_ids": artifact_ids},
+    )
+    return final_text, state
 
 
 @dataclass(frozen=True)

--- a/backend/agent/runtime/orchestrator.py
+++ b/backend/agent/runtime/orchestrator.py
@@ -12,22 +12,18 @@ from agent.llm.client import (
     AnthropicClient,
     SystemPrompt,
     format_llm_failure,
-    is_content_policy_error,
     render_system_prompt,
 )
 from agent.runtime.prompting import PromptAssembly
 from agent.context.profiles import CompactionProfile, resolve_compaction_profile
 from agent.memory.store import PersistentMemoryStore
 from agent.runtime.hooks import (
-    ContextCompactionContext,
-    ContextCompactionResult,
     ConversationHooks,
     NoopConversationHooks,
 )
 from agent.runtime.helpers import (
     apply_response_to_state,
-    extract_final_text,
-    extract_final_text_from_messages,
+    finalize_conversation_turn,
     find_last_user_message_index,
     get_last_user_message_text,
     process_tool_calls,
@@ -36,21 +32,13 @@ from agent.runtime.message_chain import (
     collect_message_chain_warnings,
     tool_calls_fingerprint,
 )
-from agent.context.compaction import Observer, compaction_summary_for_persistence
-from agent.runtime.skill_install import install_skill_dependencies_for_turn
-from agent.runtime.skill_runtime import split_allowed_tools
-from agent.runtime.skill_setup import (
-    build_skill_prompt_content,
-    emit_redundant_skill_activation,
-    prepare_skill_for_turn,
-    tool_use_had_error_result,
-)
-from agent.runtime.skill_selector import select_skill_for_message
+from agent.context.compaction import Observer
+from agent.context.compaction_step import CompactionStep
+from agent.runtime.skill_activation import SkillActivation, SkillActivationController
 from agent.runtime.turn_attachments import (
     build_user_message_content,
     upload_attachments_to_sandbox,
 )
-from agent.runtime.skill_selector import AttachmentDescriptor
 from agent.skills.loader import SkillRegistry
 from agent.tools.executor import ToolExecutor
 from agent.tools.registry import ToolRegistry
@@ -148,20 +136,31 @@ class AgentOrchestrator:
         self._cancel_event = asyncio.Event()
         self._state = AgentState(messages=initial_messages)
         self._skill_registry = skill_registry
+        self._skill_controller = SkillActivationController(
+            skill_registry=skill_registry,
+            executor=tool_executor,
+            emitter=event_emitter,
+            client=claude_client,
+            install_context="orchestrator",
+        )
         self._conversation_hooks = conversation_hooks or NoopConversationHooks()
         self._conversation_id = conversation_id
         self._hook_user_id = hook_user_id
-        self._auto_injected_skill: str | None = None
+        self._compaction_step = CompactionStep(
+            observer=self._observer,
+            profile=self._compaction_profile,
+            emitter=event_emitter,
+            summary_scope="conversation",
+            conversation_id=conversation_id,
+            user_id=hook_user_id,
+            persistent_store=persistent_store,
+            hooks=self._conversation_hooks,
+        )
         self._run_lock = asyncio.Lock()
         self._last_tool_batch_signature: str | None = None
         self._identical_tool_batch_count: int = 0
         self._turn_artifact_ids: list[str] = []
-        self._turn_prompt_assembly = base_prompt_assembly
-        self._turn_unfiltered_registry = tool_registry
-        self._pending_mid_turn_update: (
-            tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None
-        ) = None
-        self._processed_skill_activation_tool_ids: set[str] = set()
+        self._pending_mid_turn_update: SkillActivation | None = None
         self._current_turn_start_index = len(initial_messages)
         self._current_turn_base_messages = initial_messages
 
@@ -202,99 +201,6 @@ class AgentOrchestrator:
         ):
             return self._state.messages[len(base_messages) :]
         return ()
-
-    def _requested_skill_name_from_tool_call(
-        self, tool_call_name: str, tool_input: dict[str, Any]
-    ) -> str | None:
-        if self._skill_registry is None:
-            return None
-        if tool_call_name == "activate_skill":
-            name = tool_input.get("name")
-            return name if isinstance(name, str) and name else None
-        if self._skill_registry.find_by_name(tool_call_name) is not None:
-            return tool_call_name
-        return None
-
-    async def _apply_mid_turn_skill_activation(
-        self,
-        skill_name: str,
-        *,
-        tool_id: str | None,
-    ) -> tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None:
-        if self._skill_registry is None:
-            return None
-
-        if tool_id is not None and tool_id in self._processed_skill_activation_tool_ids:
-            return None
-
-        if skill_name == self._auto_injected_skill:
-            await emit_redundant_skill_activation(
-                self._emitter,
-                skill_name=skill_name,
-                tool_id=tool_id,
-                messages=list(self._state.messages),
-            )
-            if tool_id is not None:
-                self._processed_skill_activation_tool_ids.add(tool_id)
-            return None
-
-        skill = self._skill_registry.find_by_name(skill_name)
-        if skill is None:
-            return None
-
-        self._auto_injected_skill = skill.metadata.name
-        prompt_assembly = self._turn_prompt_assembly.with_volatile_sections(
-            build_skill_prompt_content(skill),
-        )
-
-        from agent.tools.local.activate_skill import ActivateSkill
-
-        updated_registry = self._turn_unfiltered_registry.replace_tool(
-            ActivateSkill(
-                skill_registry=self._skill_registry,
-                active_skill_name=skill.metadata.name,
-            )
-        )
-
-        reset_allowed_tools = getattr(self._executor, "reset_allowed_tools", None)
-        if callable(reset_allowed_tools):
-            reset_allowed_tools()
-
-        await prepare_skill_for_turn(
-            executor=self._executor,
-            skill=skill,
-            emitter=self._emitter,
-            source="mid_turn",
-            install_dependencies=lambda: install_skill_dependencies_for_turn(
-                self._executor,
-                skill.metadata.dependencies,
-                self._emitter,
-                context="orchestrator_mid_turn",
-                skill_name=skill.metadata.name,
-                source="mid_turn",
-                raise_on_error=True,
-            ),
-        )
-
-        if skill.metadata.allowed_tools:
-            allowed_names, allowed_tags = split_allowed_tools(
-                skill.metadata.allowed_tools
-            )
-            set_allowed_tools = getattr(self._executor, "set_allowed_tools", None)
-            if callable(set_allowed_tools):
-                set_allowed_tools(allowed_names, allowed_tags)
-            updated_registry = updated_registry.filter_by_names_or_tags(
-                allowed_names, allowed_tags
-            )
-
-        tools = updated_registry.to_anthropic_tools(
-            cache_breakpoint=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False)
-        )
-        if tool_id is not None:
-            self._processed_skill_activation_tool_ids.add(tool_id)
-
-        logger.info("mid_turn_skill_activated name={}", skill.metadata.name)
-        return prompt_assembly, updated_registry, tools
 
     @staticmethod
     def _append_text_guard_to_last_user_message(
@@ -388,19 +294,16 @@ class AgentOrchestrator:
         )
         if callable(reset_active_skill_directory):
             reset_active_skill_directory()
-        self._registry = self._base_registry
-        self._turn_unfiltered_registry = self._base_registry
         self._last_tool_batch_signature = None
         self._identical_tool_batch_count = 0
         self._pending_mid_turn_update = None
-        self._processed_skill_activation_tool_ids = set()
         self._current_turn_start_index = len(self._state.messages)
         self._current_turn_base_messages = self._state.messages
 
         # Append user message to existing state (preserves conversation history)
         self._task_complete_summary = None
 
-        # Auto-match skill for this turn via shared selector
+        # Auto-match skill for this turn via the shared activation controller
         cache_prompt = getattr(get_settings(), "PROMPT_CACHE_ENABLED", False)
         prompt_assembly = self._base_prompt_assembly
         if runtime_prompt_sections:
@@ -411,66 +314,28 @@ class AgentOrchestrator:
                 prompt_assembly = prompt_assembly.with_volatile_sections(
                     *dynamic_sections,
                 )
-        self._turn_prompt_assembly = prompt_assembly
-        self._auto_injected_skill = None
-        settings = get_settings()
-        matched = await select_skill_for_message(
-            user_message=user_message,
-            selected_skills=selected_skills,
-            attachment_descriptors=tuple(
-                AttachmentDescriptor(
-                    filename=str(getattr(attachment, "filename", "") or ""),
-                    content_type=str(getattr(attachment, "content_type", "") or ""),
-                )
-                for attachment in attachments
-            ),
-            skill_registry=self._skill_registry,
-            client=self._client,
-            model=settings.SKILL_SELECTOR_MODEL or settings.LITE_MODEL,
-        )
-        if matched is not None:
-            self._auto_injected_skill = matched.metadata.name
-            explicit_skill_name = next((s for s in selected_skills if s.strip()), None)
-            source = "explicit" if explicit_skill_name is not None else "auto"
-            # Replace ActivateSkill tool with active skill name (copy-on-write)
-            from agent.tools.local.activate_skill import ActivateSkill
 
-            self._registry = self._registry.replace_tool(
-                ActivateSkill(
-                    skill_registry=self._skill_registry,
-                    active_skill_name=matched.metadata.name,
+        self._skill_controller.begin_turn(
+            prompt_assembly=prompt_assembly,
+            registry=self._base_registry,
+        )
+        try:
+            activation, _matched = (
+                await self._skill_controller.match_and_activate_turn_start(
+                    user_message=user_message,
+                    selected_skills=selected_skills,
+                    prompt_assembly=prompt_assembly,
+                    registry=self._base_registry,
+                    cache_prompt=cache_prompt,
+                    attachments=attachments,
                 )
             )
-            self._turn_unfiltered_registry = self._registry
-            try:
-                await prepare_skill_for_turn(
-                    executor=self._executor,
-                    skill=matched,
-                    emitter=self._emitter,
-                    source=source,
-                    install_dependencies=lambda: install_skill_dependencies_for_turn(
-                        self._executor,
-                        matched.metadata.dependencies,
-                        self._emitter,
-                        context="orchestrator",
-                        skill_name=matched.metadata.name,
-                        source=source,
-                        raise_on_error=True,
-                    ),
-                )
-            except Exception as exc:
-                error = str(exc)
-                await self._emit_task_error(
-                    error,
-                    code="skill_setup",
-                    retryable=False,
-                )
-                return f"Error: {error}"
-            prompt_assembly = prompt_assembly.with_volatile_sections(
-                build_skill_prompt_content(matched),
-            )
-        else:
-            self._turn_unfiltered_registry = self._registry
+        except Exception as exc:
+            error = str(exc)
+            await self._emit_task_error(error, code="skill_setup", retryable=False)
+            return f"Error: {error}"
+        prompt_assembly = activation.prompt_assembly
+        tools = activation.tools
 
         uploaded_paths: tuple[str, ...] = ()
         if attachments:
@@ -501,27 +366,6 @@ class AgentOrchestrator:
         self._state = replace(self._state, completed=False, error=None, iteration=0)
         self._turn_artifact_ids = []
 
-        # Filter tools to skill's allowed set (if specified).
-        # Entries containing ":" are treated as registry tags (e.g.
-        # "mcp_server:my-server"); all others are plain tool names.
-        effective_registry = self._registry
-        if (
-            self._auto_injected_skill is not None
-            and matched is not None
-            and matched.metadata.allowed_tools
-        ):
-            allowed_names, allowed_tags = split_allowed_tools(
-                matched.metadata.allowed_tools
-            )
-            set_allowed_tools = getattr(self._executor, "set_allowed_tools", None)
-            if callable(set_allowed_tools):
-                set_allowed_tools(allowed_names, allowed_tags)
-            effective_registry = self._registry.filter_by_names_or_tags(
-                allowed_names, allowed_tags
-            )
-
-        tools = effective_registry.to_anthropic_tools(cache_breakpoint=cache_prompt)
-
         while not self._state.completed and self._state.error is None:
             if self._cancel_event.is_set():
                 break
@@ -533,126 +377,29 @@ class AgentOrchestrator:
                 prompt_assembly.rendered,
             )
 
-            if self._pending_mid_turn_update is not None:
-                prompt_assembly, effective_registry, tools = (
-                    self._pending_mid_turn_update
+            update = self._pending_mid_turn_update
+            self._pending_mid_turn_update = None
+            if update is None:
+                # Check if activate_skill was invoked mid-turn (assistant scan)
+                update = await self._skill_controller.check_mid_turn_from_messages(
+                    list(self._state.messages),
+                    cache_prompt=cache_prompt,
                 )
-                self._pending_mid_turn_update = None
-
-            # Check if activate_skill was invoked mid-turn and enforce constraints
-            updated = await self._check_mid_turn_skill_activation()
-            if updated is not None:
-                prompt_assembly, effective_registry, tools = updated
+            if update is not None:
+                prompt_assembly = update.prompt_assembly
+                tools = update.tools
 
         logger.info("turn_complete iterations={}", self._state.iteration)
 
-        if self._cancel_event.is_set():
-            self._cancel_event.clear()
-            current_turn_messages = self._current_turn_messages_for_cancel()
-            final_text = extract_final_text_from_messages(current_turn_messages)
-            await self._emitter.emit(
-                EventType.TURN_CANCELLED,
-                {"result": final_text},
-            )
-            # Reset so the orchestrator can accept new turns
-            self._state = replace(
-                self._state,
-                messages=self._current_turn_base_messages,
-                completed=False,
-                error=None,
-            )
-            return final_text
-
-        if self._state.error:
-            err_msg = self._state.error
-            retryable = "LLM call failed" in err_msg
-            code = "llm_error" if retryable else "agent_error"
-            if is_content_policy_error(err_msg):
-                code = "content_policy"
-                retryable = False
-            if "maximum iterations" in err_msg.lower():
-                code = "max_iterations"
-                retryable = False
-            await self._emit_task_error(err_msg, code=code, retryable=retryable)
-            return f"Error: {self._state.error}"
-
-        final_text = extract_final_text(self._state)
-        await self._emitter.emit(
-            EventType.TURN_COMPLETE,
-            {"result": final_text, "artifact_ids": self._turn_artifact_ids},
+        final_text, self._state = await finalize_conversation_turn(
+            state=self._state,
+            cancel_event=self._cancel_event,
+            current_turn_messages=self._current_turn_messages_for_cancel(),
+            base_messages=self._current_turn_base_messages,
+            emitter=self._emitter,
+            artifact_ids=self._turn_artifact_ids,
         )
         return final_text
-
-    async def _check_mid_turn_skill_activation(
-        self,
-    ) -> tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None:
-        """Detect a successful mid-turn activate_skill call and enforce constraints.
-
-        Returns (effective_prompt, effective_registry, tools) if a new skill was
-        activated, or None if no change occurred.
-        """
-        if self._skill_registry is None:
-            return None
-
-        # Look at the last assistant message for activate_skill tool_use blocks
-        last_assistant = None
-        for msg in reversed(self._state.messages):
-            if msg.get("role") == "assistant":
-                last_assistant = msg
-                break
-
-        if last_assistant is None:
-            return None
-
-        content = last_assistant.get("content")
-        if not isinstance(content, list):
-            return None
-
-        # Find activate_skill tool_use block (single pass)
-        activated_name: str | None = None
-        tool_id: str | None = None
-        for block in content:
-            if not isinstance(block, dict) or block.get("type") != "tool_use":
-                continue
-            block_name = block.get("name")
-            if block_name == "activate_skill":
-                skill_input = block.get("input", {})
-                activated_name = skill_input.get("name")
-                tool_id = block.get("id")
-                break
-            if (
-                isinstance(block_name, str)
-                and self._skill_registry.find_by_name(block_name) is not None
-            ):
-                activated_name = block_name
-                tool_id = block.get("id")
-                break
-
-        if not activated_name:
-            return None
-
-        if tool_id is not None and tool_id in self._processed_skill_activation_tool_ids:
-            return None
-
-        if tool_id is not None and tool_use_had_error_result(
-            list(self._state.messages),
-            tool_id,
-        ):
-            return None
-
-        if activated_name == self._auto_injected_skill:
-            await emit_redundant_skill_activation(
-                self._emitter,
-                skill_name=activated_name,
-                tool_id=tool_id,
-                messages=list(self._state.messages),
-            )
-            return None
-
-        return await self._apply_mid_turn_skill_activation(
-            activated_name,
-            tool_id=tool_id,
-        )
 
     async def _run_iteration(
         self,
@@ -672,43 +419,13 @@ class AgentOrchestrator:
                 logger.warning("message_chain_warning detail={}", w)
 
         # Compact message history before the LLM call if needed
-        if self._observer.should_compact(state.messages, effective_prompt):
+        compacted, did_compact = await self._compaction_step.maybe_compact(
+            state.messages,
+            effective_prompt,
+            iteration=state.iteration,
+        )
+        if did_compact:
             logger.debug("compacting_message_history")
-            compaction_context = ContextCompactionContext(
-                conversation_id=self._conversation_id,
-                user_id=self._hook_user_id,
-                messages=state.messages,
-                effective_prompt=effective_prompt,
-                profile_name=self._compaction_profile.name,
-                metadata={
-                    "memory_flush": self._compaction_profile.memory_flush,
-                    "persistent_store": self._persistent_store,
-                },
-            )
-            await self._conversation_hooks.before_context_compaction(
-                compaction_context,
-            )
-            compacted = await self._observer.compact(state.messages, effective_prompt)
-            summary_text = compaction_summary_for_persistence(compacted)
-            await self._emitter.emit(
-                EventType.CONTEXT_COMPACTED,
-                {
-                    "original_messages": len(state.messages),
-                    "compacted_messages": len(compacted),
-                    "summary_text": summary_text,
-                    "summary_scope": "conversation",
-                    "compaction_profile": self._compaction_profile.name,
-                },
-                iteration=state.iteration,
-            )
-            await self._conversation_hooks.after_context_compaction(
-                compaction_context,
-                ContextCompactionResult(
-                    original_message_count=len(state.messages),
-                    compacted_messages=compacted,
-                    summary_text=summary_text,
-                ),
-            )
             state = replace(state, messages=compacted)
 
         logger.info("iteration={}/{}", state.iteration, self._max_iterations)
@@ -817,12 +534,14 @@ class AgentOrchestrator:
             return state.mark_completed()
 
         async def _post_tool_callback(tc: Any, result: Any) -> None:
-            skill_name = self._requested_skill_name_from_tool_call(tc.name, tc.input)
+            skill_name = self._skill_controller.requested_skill_name(tc.name, tc.input)
             if skill_name is None or not result.success:
                 return
-            updated = await self._apply_mid_turn_skill_activation(
+            updated = await self._skill_controller.apply_mid_turn(
                 skill_name,
                 tool_id=tc.id,
+                messages=list(state.messages),
+                cache_prompt=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False),
             )
             if updated is not None:
                 self._pending_mid_turn_update = updated

--- a/backend/agent/runtime/orchestrator.py
+++ b/backend/agent/runtime/orchestrator.py
@@ -10,9 +10,8 @@ from loguru import logger
 
 from agent.llm.client import (
     AnthropicClient,
+    LLMResponse,
     SystemPrompt,
-    format_llm_failure,
-    render_system_prompt,
 )
 from agent.runtime.prompting import PromptAssembly
 from agent.context.profiles import CompactionProfile, resolve_compaction_profile
@@ -22,19 +21,17 @@ from agent.runtime.hooks import (
     NoopConversationHooks,
 )
 from agent.runtime.helpers import (
-    apply_response_to_state,
     finalize_conversation_turn,
     find_last_user_message_index,
     get_last_user_message_text,
-    process_tool_calls,
 )
 from agent.runtime.message_chain import (
-    collect_message_chain_warnings,
     tool_calls_fingerprint,
 )
 from agent.context.compaction import Observer
 from agent.context.compaction_step import CompactionStep
-from agent.runtime.skill_activation import SkillActivation, SkillActivationController
+from agent.runtime.engine import AgentLoop, LoopConfig, LoopPolicy
+from agent.runtime.skill_activation import SkillActivationController
 from agent.runtime.turn_attachments import (
     build_user_message_content,
     upload_attachments_to_sandbox,
@@ -81,7 +78,7 @@ class AgentState:
         return replace(self, error=error)
 
 
-class AgentOrchestrator:
+class AgentOrchestrator(LoopPolicy):
     """Runs a single-agent ReAct loop until completion or max iterations."""
 
     def __init__(
@@ -160,9 +157,16 @@ class AgentOrchestrator:
         self._last_tool_batch_signature: str | None = None
         self._identical_tool_batch_count: int = 0
         self._turn_artifact_ids: list[str] = []
-        self._pending_mid_turn_update: SkillActivation | None = None
         self._current_turn_start_index = len(initial_messages)
         self._current_turn_base_messages = initial_messages
+        self._loop = AgentLoop(
+            client=claude_client,
+            emitter=event_emitter,
+            executor=tool_executor,
+            compaction_step=self._compaction_step,
+            skill_controller=self._skill_controller,
+            policy=self,
+        )
 
     async def on_task_complete(self, summary: str) -> None:
         """Callback for the task_complete tool."""
@@ -296,7 +300,6 @@ class AgentOrchestrator:
             reset_active_skill_directory()
         self._last_tool_batch_signature = None
         self._identical_tool_batch_count = 0
-        self._pending_mid_turn_update = None
         self._current_turn_start_index = len(self._state.messages)
         self._current_turn_base_messages = self._state.messages
 
@@ -366,28 +369,12 @@ class AgentOrchestrator:
         self._state = replace(self._state, completed=False, error=None, iteration=0)
         self._turn_artifact_ids = []
 
-        while not self._state.completed and self._state.error is None:
-            if self._cancel_event.is_set():
-                break
-            self._state = self._state.increment_iteration()
-            self._state = await self._run_iteration(
-                self._state,
-                tools,
-                prompt_assembly.system_with_cache_control(cache_prompt),
-                prompt_assembly.rendered,
-            )
-
-            update = self._pending_mid_turn_update
-            self._pending_mid_turn_update = None
-            if update is None:
-                # Check if activate_skill was invoked mid-turn (assistant scan)
-                update = await self._skill_controller.check_mid_turn_from_messages(
-                    list(self._state.messages),
-                    cache_prompt=cache_prompt,
-                )
-            if update is not None:
-                prompt_assembly = update.prompt_assembly
-                tools = update.tools
+        self._state = await self._loop.run_turn(
+            state=self._state,
+            prompt_assembly=prompt_assembly,
+            tools=tools,
+            cache_prompt=cache_prompt,
+        )
 
         logger.info("turn_complete iterations={}", self._state.iteration)
 
@@ -401,167 +388,33 @@ class AgentOrchestrator:
         )
         return final_text
 
-    async def _run_iteration(
+    @property
+    def loop_config(self) -> LoopConfig:
+        settings = get_settings()
+        return LoopConfig(
+            max_iterations=self._max_iterations,
+            thinking_budget=self._thinking_budget,
+            emit_thinking=True,
+            validate_message_chain=settings.VALIDATE_AGENT_MESSAGE_CHAIN,
+            debug_label="orchestrator",
+            debug_logging=getattr(settings, "AGENT_DEBUG_LOGGING", False),
+        )
+
+    def loop_cancel_requested(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def loop_stop_processing(self) -> bool:
+        return self._task_complete_summary is not None
+
+    async def loop_on_tools_processed(
         self,
         state: AgentState,
-        tools: list[dict[str, Any]],
-        system_prompt: SystemPrompt | None = None,
-        system_prompt_text: str | None = None,
+        response: LLMResponse,
+        tool_result: Any,
     ) -> AgentState:
-        """Run a single iteration of the ReAct loop."""
-        effective_system = system_prompt or self._system_prompt
-        effective_prompt = system_prompt_text or render_system_prompt(effective_system)
-
-        settings = get_settings()
-        if settings.VALIDATE_AGENT_MESSAGE_CHAIN:
-            chain_warnings = collect_message_chain_warnings(state.messages)
-            for w in chain_warnings:
-                logger.warning("message_chain_warning detail={}", w)
-
-        # Compact message history before the LLM call if needed
-        compacted, did_compact = await self._compaction_step.maybe_compact(
-            state.messages,
-            effective_prompt,
-            iteration=state.iteration,
-        )
-        if did_compact:
-            logger.debug("compacting_message_history")
-            state = replace(state, messages=compacted)
-
-        logger.info("iteration={}/{}", state.iteration, self._max_iterations)
-
-        await self._emitter.emit(
-            EventType.ITERATION_START,
-            {"iteration": state.iteration},
-            iteration=state.iteration,
-        )
-
-        if state.iteration > self._max_iterations:
-            logger.warning("max_iterations_exceeded limit={}", self._max_iterations)
-            return state.mark_error(
-                f"Exceeded maximum iterations ({self._max_iterations})",
-            )
-
-        llm_model = getattr(self._client, "default_model", "<unknown>")
-        debug_logging_enabled = getattr(get_settings(), "AGENT_DEBUG_LOGGING", False)
-        try:
-            thinking_emitted_during_stream = False
-
-            async def _on_text_delta(delta: str) -> None:
-                await self._emitter.emit(
-                    EventType.TEXT_DELTA,
-                    {"delta": delta},
-                    iteration=state.iteration,
-                )
-
-            async def _on_thinking_ready(thinking: str) -> None:
-                nonlocal thinking_emitted_during_stream
-                if not thinking:
-                    return
-                thinking_emitted_during_stream = True
-                await self._emitter.emit(
-                    EventType.THINKING,
-                    {"thinking": thinking},
-                    iteration=state.iteration,
-                )
-
-            stream_kwargs = dict(
-                system=effective_system,
-                messages=list(state.messages),
-                tools=tools if tools else None,
-                on_text_delta=_on_text_delta,
-                thinking_budget=self._thinking_budget,
-            )
-            if debug_logging_enabled:
-                logger.debug(
-                    "orchestrator_llm_call model={} iteration={} messages={} tools={} thinking_budget={}",
-                    llm_model,
-                    state.iteration,
-                    len(state.messages),
-                    len(tools),
-                    self._thinking_budget,
-                )
-            try:
-                response = await self._client.create_message_stream(
-                    **stream_kwargs,
-                    on_thinking_ready=_on_thinking_ready,
-                )
-            except TypeError as exc:
-                if "on_thinking_ready" not in str(exc):
-                    raise
-                response = await self._client.create_message_stream(**stream_kwargs)
-        except Exception as exc:
-            if debug_logging_enabled:
-                logger.debug(
-                    "orchestrator_llm_exception model={} iteration={} error_type={}",
-                    llm_model,
-                    state.iteration,
-                    type(exc).__name__,
-                )
-            logger.error("llm_call_failed model={} error={}", llm_model, exc)
-            return state.mark_error(format_llm_failure(exc))
-
-        logger.info(
-            "llm_response model={} stop_reason={} tool_calls={} input_tokens={} output_tokens={}",
-            llm_model,
-            response.stop_reason,
-            len(response.tool_calls),
-            response.usage.input_tokens,
-            response.usage.output_tokens,
-        )
-
-        if response.thinking and not thinking_emitted_during_stream:
-            await self._emitter.emit(
-                EventType.THINKING,
-                {"thinking": response.thinking},
-                iteration=state.iteration,
-            )
-
-        await self._emitter.emit(
-            EventType.LLM_RESPONSE,
-            {
-                "text": response.text,
-                "tool_call_count": len(response.tool_calls),
-                "stop_reason": response.stop_reason,
-                "usage": response.usage,
-            },
-            iteration=state.iteration,
-        )
-
-        state = apply_response_to_state(state, response)
-
-        if not response.tool_calls:
-            return state.mark_completed()
-
-        async def _post_tool_callback(tc: Any, result: Any) -> None:
-            skill_name = self._skill_controller.requested_skill_name(tc.name, tc.input)
-            if skill_name is None or not result.success:
-                return
-            updated = await self._skill_controller.apply_mid_turn(
-                skill_name,
-                tool_id=tc.id,
-                messages=list(state.messages),
-                cache_prompt=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False),
-            )
-            if updated is not None:
-                self._pending_mid_turn_update = updated
-
-        try:
-            tool_result = await process_tool_calls(
-                state=state,
-                tool_calls=response.tool_calls,
-                executor=self._executor,
-                emitter=self._emitter,
-                stop_check=lambda: self._task_complete_summary is not None,
-                cancel_check=lambda: self._cancel_event.is_set(),
-                post_tool_callback=_post_tool_callback,
-            )
-        except Exception as exc:
-            return state.mark_error(str(exc))
-        state = tool_result.state
         self._turn_artifact_ids.extend(tool_result.artifact_ids)
 
-        threshold = settings.STUCK_LOOP_TOOL_REPEAT_THRESHOLD
+        threshold = get_settings().STUCK_LOOP_TOOL_REPEAT_THRESHOLD
         if threshold > 0 and response.tool_calls:
             sig = tool_calls_fingerprint(response.tool_calls)
             if sig == self._last_tool_batch_signature:
@@ -586,9 +439,9 @@ class AgentOrchestrator:
                 state = self._append_text_guard_to_last_user_message(state, nudge)
                 self._identical_tool_batch_count = 0
                 self._last_tool_batch_signature = None
+        return state
 
-        # Check if task_complete tool was invoked during tool processing
+    async def loop_on_task_complete(self, state: AgentState) -> AgentState | None:
         if self._task_complete_summary is not None:
             return state.mark_completed(self._task_complete_summary)
-
-        return state
+        return None

--- a/backend/agent/runtime/planner.py
+++ b/backend/agent/runtime/planner.py
@@ -14,25 +14,22 @@ from agent.llm.client import (
     AnthropicClient,
     LLMResponse,
     SystemPrompt,
-    format_llm_failure,
-    render_system_prompt,
 )
 from agent.runtime.hooks import (
     ConversationHooks,
     NoopConversationHooks,
 )
 from agent.runtime.helpers import (
-    apply_response_to_state,
     finalize_conversation_turn,
     find_last_user_message_index,
     get_last_user_message_text,
-    process_tool_calls,
 )
 from agent.context.compaction import Observer
 from agent.context.compaction_step import CompactionStep
+from agent.runtime.engine import AgentLoop, LoopConfig, LoopPolicy
 from agent.runtime.orchestrator import AgentState
 from agent.runtime.prompting import PromptAssembly
-from agent.runtime.skill_activation import SkillActivation, SkillActivationController
+from agent.runtime.skill_activation import SkillActivationController
 from agent.runtime.task_runner import TaskAgentConfig
 from agent.runtime.turn_attachments import (
     build_user_message_content,
@@ -254,7 +251,7 @@ class SubAgentManagerProtocol(Protocol):
         ...
 
 
-class PlannerOrchestrator:
+class PlannerOrchestrator(LoopPolicy):
     """Top-level orchestrator that decomposes requests into sub-agent tasks.
 
     Uses a planning model to reason about task decomposition and coordinates
@@ -367,11 +364,19 @@ class PlannerOrchestrator:
             hooks=self._conversation_hooks,
         )
 
+        self._loop = AgentLoop(
+            client=claude_client,
+            emitter=event_emitter,
+            executor=self._executor,
+            compaction_step=self._compaction_step,
+            skill_controller=self._skill_controller,
+            policy=self,
+        )
+
         # Persistent conversation state — appended to on each run() call
         self._state = AgentState(messages=initial_messages)
         self._run_lock = asyncio.Lock()
         self._turn_artifact_ids: list[str] = []
-        self._pending_mid_turn_update: SkillActivation | None = None
         self._current_turn_start_index = len(initial_messages)
         self._current_turn_base_messages = initial_messages
         self._explicit_planner_requested = False
@@ -485,7 +490,6 @@ class PlannerOrchestrator:
         if callable(reset_active_skill_directory):
             reset_active_skill_directory()
         self._task_complete_summary = None
-        self._pending_mid_turn_update = None
         self._current_turn_start_index = len(self._state.messages)
         self._current_turn_base_messages = self._state.messages
         explicit_planner = bool((turn_metadata or {}).get("explicit_planner"))
@@ -565,125 +569,62 @@ class PlannerOrchestrator:
         self._state = replace(self._state, completed=False, error=None, iteration=0)
         self._turn_artifact_ids = []
 
-        model = get_settings().PLANNING_MODEL
-
         try:
-            while not self._state.completed and self._state.error is None:
-                if self._cancel_event.is_set():
-                    break
-                iteration_prompt_assembly = prompt_assembly
-                if self._explicit_policy_reminder:
-                    iteration_prompt_assembly = (
-                        iteration_prompt_assembly.with_volatile_sections(
-                            self._explicit_policy_reminder
-                        )
-                    )
-                self._state = self._state.increment_iteration()
-                self._state = await self._run_iteration(
-                    self._state,
-                    tools,
-                    model,
-                    iteration_prompt_assembly.system_with_cache_control(cache_prompt),
-                    iteration_prompt_assembly.rendered,
-                )
-
-                update = self._pending_mid_turn_update
-                self._pending_mid_turn_update = None
-                if update is None:
-                    update = await self._skill_controller.check_mid_turn_from_messages(
-                        list(self._state.messages),
-                        cache_prompt=cache_prompt,
-                    )
-                if update is not None:
-                    prompt_assembly = update.prompt_assembly
-                    tools = update.tools
+            self._state = await self._loop.run_turn(
+                state=self._state,
+                prompt_assembly=prompt_assembly,
+                tools=tools,
+                cache_prompt=cache_prompt,
+            )
         finally:
             await self._cleanup_sub_agents()
 
         return await self._finalize(self._state)
 
-    async def _run_iteration(
+    @property
+    def loop_config(self) -> LoopConfig:
+        return LoopConfig(
+            max_iterations=self._max_iterations,
+            model=get_settings().PLANNING_MODEL,
+            debug_label="planner",
+            debug_logging=getattr(get_settings(), "AGENT_DEBUG_LOGGING", False),
+        )
+
+    def loop_cancel_requested(self) -> bool:
+        return self._cancel_event.is_set()
+
+    def loop_stop_processing(self) -> bool:
+        return self._task_complete_summary is not None
+
+    def loop_iteration_prompt(self, assembly: PromptAssembly) -> PromptAssembly:
+        if self._explicit_policy_reminder:
+            return assembly.with_volatile_sections(self._explicit_policy_reminder)
+        return assembly
+
+    async def loop_on_no_tool_calls(
+        self, state: AgentState, response: LLMResponse
+    ) -> AgentState:
+        if self._explicit_planner_completion_is_exempt(response.text):
+            self._explicit_policy_reminder = None
+            return state.mark_completed()
+        policy_state = await self._apply_explicit_planner_policy(
+            state,
+            trigger="inline_completion",
+        )
+        if policy_state is not None:
+            return policy_state
+        return state.mark_completed()
+
+    async def loop_on_tools_processed(
         self,
         state: AgentState,
-        tools: list[dict[str, Any]],
-        model: str,
-        system_prompt: SystemPrompt | None = None,
-        system_prompt_text: str | None = None,
+        response: LLMResponse,
+        tool_result: Any,
     ) -> AgentState:
-        """Run a single iteration of the planner ReAct loop."""
-        effective_system = system_prompt or self._system_prompt
-        effective_prompt = system_prompt_text or render_system_prompt(effective_system)
-
-        # Compact history before the LLM call if needed
-        compacted, did_compact = await self._compaction_step.maybe_compact(
-            state.messages,
-            effective_prompt,
-            iteration=state.iteration,
-        )
-        if did_compact:
-            state = replace(state, messages=compacted)
-
-        await self._emitter.emit(
-            EventType.ITERATION_START,
-            {"iteration": state.iteration},
-            iteration=state.iteration,
-        )
-
-        if state.iteration > self._max_iterations:
-            return state.mark_error(
-                f"Exceeded maximum iterations ({self._max_iterations})",
-            )
-
-        response, llm_error = await self._call_llm(
-            state, tools, model, effective_system, effective_prompt
-        )
-        if llm_error is not None:
-            return state.mark_error(llm_error)
-
-        await self._emit_llm_response(state, response)
-
-        state = apply_response_to_state(state, response)
-
-        if not response.tool_calls:
-            if self._explicit_planner_completion_is_exempt(response.text):
-                self._explicit_policy_reminder = None
-                return state.mark_completed()
-            policy_state = await self._apply_explicit_planner_policy(
-                state,
-                trigger="inline_completion",
-            )
-            if policy_state is not None:
-                return policy_state
-            return state.mark_completed()
-
-        async def _post_tool_callback(tc: Any, result: Any) -> None:
-            skill_name = self._skill_controller.requested_skill_name(tc.name, tc.input)
-            if skill_name is None or not result.success:
-                return
-            updated = await self._skill_controller.apply_mid_turn(
-                skill_name,
-                tool_id=tc.id,
-                messages=list(state.messages),
-                cache_prompt=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False),
-            )
-            if updated is not None:
-                self._pending_mid_turn_update = updated
-
-        try:
-            tool_result = await process_tool_calls(
-                state=state,
-                tool_calls=response.tool_calls,
-                executor=self._executor,
-                emitter=self._emitter,
-                stop_check=lambda: self._task_complete_summary is not None,
-                cancel_check=lambda: self._cancel_event.is_set(),
-                post_tool_callback=_post_tool_callback,
-            )
-        except Exception as exc:
-            return state.mark_error(str(exc))
-        state = tool_result.state
         self._turn_artifact_ids.extend(tool_result.artifact_ids)
+        return state
 
+    async def loop_on_task_complete(self, state: AgentState) -> AgentState | None:
         if self._task_complete_summary is not None:
             policy_state = await self._apply_explicit_planner_policy(
                 state,
@@ -692,55 +633,7 @@ class PlannerOrchestrator:
             if policy_state is not None:
                 return policy_state
             return state.mark_completed(self._task_complete_summary)
-
-        return state
-
-    async def _call_llm(
-        self,
-        state: AgentState,
-        tools: list[dict[str, Any]],
-        model: str,
-        system_prompt: SystemPrompt | None = None,
-        system_prompt_text: str | None = None,
-    ) -> tuple[LLMResponse | None, str | None]:
-        """Call the LLM with streaming and return the response or an error."""
-        try:
-
-            async def _on_text_delta(delta: str) -> None:
-                await self._emitter.emit(
-                    EventType.TEXT_DELTA,
-                    {"delta": delta},
-                    iteration=state.iteration,
-                )
-
-            response = await self._client.create_message_stream(
-                system=system_prompt or self._system_prompt,
-                messages=list(state.messages),
-                tools=tools if tools else None,
-                model=model,
-                on_text_delta=_on_text_delta,
-            )
-            return response, None
-        except Exception as exc:
-            logger.exception("llm_call_failed_planning model={} error={}", model, exc)
-            return None, format_llm_failure(exc)
-
-    async def _emit_llm_response(
-        self,
-        state: AgentState,
-        response: LLMResponse,
-    ) -> None:
-        """Emit an LLM_RESPONSE event."""
-        await self._emitter.emit(
-            EventType.LLM_RESPONSE,
-            {
-                "text": response.text,
-                "tool_call_count": len(response.tool_calls),
-                "stop_reason": response.stop_reason,
-                "usage": response.usage,
-            },
-            iteration=state.iteration,
-        )
+        return None
 
     def _explicit_planner_completion_is_exempt(self, text: str) -> bool:
         if not self._explicit_planner_requested:

--- a/backend/agent/runtime/planner.py
+++ b/backend/agent/runtime/planner.py
@@ -15,41 +15,29 @@ from agent.llm.client import (
     LLMResponse,
     SystemPrompt,
     format_llm_failure,
-    is_content_policy_error,
     render_system_prompt,
 )
 from agent.runtime.hooks import (
-    ContextCompactionContext,
-    ContextCompactionResult,
     ConversationHooks,
     NoopConversationHooks,
 )
 from agent.runtime.helpers import (
     apply_response_to_state,
-    extract_final_text,
-    extract_final_text_from_messages,
+    finalize_conversation_turn,
     find_last_user_message_index,
     get_last_user_message_text,
     process_tool_calls,
 )
-from agent.context.compaction import Observer, compaction_summary_for_persistence
-from agent.runtime.skill_install import install_skill_dependencies_for_turn
+from agent.context.compaction import Observer
+from agent.context.compaction_step import CompactionStep
 from agent.runtime.orchestrator import AgentState
 from agent.runtime.prompting import PromptAssembly
-from agent.runtime.skill_runtime import split_allowed_tools
-from agent.runtime.skill_setup import (
-    build_skill_prompt_content,
-    emit_redundant_skill_activation,
-    prepare_skill_for_turn,
-    tool_use_had_error_result,
-)
-from agent.runtime.skill_selector import select_skill_for_message
+from agent.runtime.skill_activation import SkillActivation, SkillActivationController
 from agent.runtime.task_runner import TaskAgentConfig
 from agent.runtime.turn_attachments import (
     build_user_message_content,
     upload_attachments_to_sandbox,
 )
-from agent.runtime.skill_selector import AttachmentDescriptor
 from agent.skills.loader import SkillRegistry
 from agent.tools.executor import ToolExecutor
 from agent.tools.meta.plan_create import PlanCreate
@@ -334,8 +322,6 @@ class PlannerOrchestrator:
         self._conversation_hooks = conversation_hooks or NoopConversationHooks()
         self._conversation_id = conversation_id
         self._hook_user_id = hook_user_id
-        self._auto_injected_skill: str | None = None
-        self._turn_prompt_assembly = base_prompt_assembly
         self._planner_state = PlannerState()
 
         # Register meta-tools into the provided registry
@@ -362,16 +348,30 @@ class PlannerOrchestrator:
 
         self._registry = registry_with_meta
         self._executor = tool_executor.with_registry(registry_with_meta)
+        self._skill_controller = SkillActivationController(
+            skill_registry=skill_registry,
+            executor=self._executor,
+            emitter=event_emitter,
+            client=claude_client,
+            install_context="planner",
+            preserved_tool_names=_PLANNER_PRESERVED_TOOL_NAMES,
+        )
+        self._compaction_step = CompactionStep(
+            observer=self._observer,
+            profile=self._compaction_profile,
+            emitter=event_emitter,
+            summary_scope="conversation",
+            conversation_id=conversation_id,
+            user_id=hook_user_id,
+            persistent_store=persistent_store,
+            hooks=self._conversation_hooks,
+        )
 
         # Persistent conversation state — appended to on each run() call
         self._state = AgentState(messages=initial_messages)
         self._run_lock = asyncio.Lock()
         self._turn_artifact_ids: list[str] = []
-        self._turn_unfiltered_registry = registry_with_meta
-        self._pending_mid_turn_update: (
-            tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None
-        ) = None
-        self._processed_skill_activation_tool_ids: set[str] = set()
+        self._pending_mid_turn_update: SkillActivation | None = None
         self._current_turn_start_index = len(initial_messages)
         self._current_turn_base_messages = initial_messages
         self._explicit_planner_requested = False
@@ -417,99 +417,6 @@ class PlannerOrchestrator:
         ):
             return self._state.messages[len(base_messages) :]
         return ()
-
-    def _requested_skill_name_from_tool_call(
-        self, tool_call_name: str, tool_input: dict[str, Any]
-    ) -> str | None:
-        if self._skill_registry is None:
-            return None
-        if tool_call_name == "activate_skill":
-            name = tool_input.get("name")
-            return name if isinstance(name, str) and name else None
-        if self._skill_registry.find_by_name(tool_call_name) is not None:
-            return tool_call_name
-        return None
-
-    async def _apply_mid_turn_skill_activation(
-        self,
-        skill_name: str,
-        *,
-        tool_id: str | None,
-    ) -> tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None:
-        if self._skill_registry is None:
-            return None
-
-        if tool_id is not None and tool_id in self._processed_skill_activation_tool_ids:
-            return None
-
-        if skill_name == self._auto_injected_skill:
-            await emit_redundant_skill_activation(
-                self._emitter,
-                skill_name=skill_name,
-                tool_id=tool_id,
-                messages=list(self._state.messages),
-            )
-            if tool_id is not None:
-                self._processed_skill_activation_tool_ids.add(tool_id)
-            return None
-
-        skill = self._skill_registry.find_by_name(skill_name)
-        if skill is None:
-            return None
-
-        self._auto_injected_skill = skill.metadata.name
-        prompt_assembly = self._turn_prompt_assembly.with_volatile_sections(
-            build_skill_prompt_content(skill),
-        )
-
-        from agent.tools.local.activate_skill import ActivateSkill
-
-        updated_registry = self._turn_unfiltered_registry.replace_tool(
-            ActivateSkill(
-                skill_registry=self._skill_registry,
-                active_skill_name=skill.metadata.name,
-            )
-        )
-
-        reset_allowed_tools = getattr(self._executor, "reset_allowed_tools", None)
-        if callable(reset_allowed_tools):
-            reset_allowed_tools()
-
-        await prepare_skill_for_turn(
-            executor=self._executor,
-            skill=skill,
-            emitter=self._emitter,
-            source="mid_turn",
-            install_dependencies=lambda: install_skill_dependencies_for_turn(
-                self._executor,
-                skill.metadata.dependencies,
-                self._emitter,
-                context="planner_mid_turn",
-                skill_name=skill.metadata.name,
-                source="mid_turn",
-                raise_on_error=True,
-            ),
-        )
-
-        if skill.metadata.allowed_tools:
-            allowed_names, allowed_tags = split_allowed_tools(
-                skill.metadata.allowed_tools,
-                preserved_names=_PLANNER_PRESERVED_TOOL_NAMES,
-            )
-            set_allowed_tools = getattr(self._executor, "set_allowed_tools", None)
-            if callable(set_allowed_tools):
-                set_allowed_tools(allowed_names, allowed_tags)
-            updated_registry = updated_registry.filter_by_names_or_tags(
-                allowed_names, allowed_tags
-            )
-
-        tools = updated_registry.to_anthropic_tools(
-            cache_breakpoint=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False)
-        )
-        if tool_id is not None:
-            self._processed_skill_activation_tool_ids.add(tool_id)
-        logger.info("planner_mid_turn_skill_activated name={}", skill.metadata.name)
-        return prompt_assembly, updated_registry, tools
 
     async def run(
         self,
@@ -578,9 +485,7 @@ class PlannerOrchestrator:
         if callable(reset_active_skill_directory):
             reset_active_skill_directory()
         self._task_complete_summary = None
-        self._auto_injected_skill = None
         self._pending_mid_turn_update = None
-        self._processed_skill_activation_tool_ids = set()
         self._current_turn_start_index = len(self._state.messages)
         self._current_turn_base_messages = self._state.messages
         explicit_planner = bool((turn_metadata or {}).get("explicit_planner"))
@@ -607,83 +512,30 @@ class PlannerOrchestrator:
         locale_sections = _build_turn_locale_runtime_sections(turn_metadata)
         if locale_sections:
             prompt_assembly = prompt_assembly.with_volatile_sections(*locale_sections)
-        self._turn_prompt_assembly = prompt_assembly
-
-        # Skill matching via shared selector (before user message / uploads)
-        effective_registry = self._registry
-        matched = await select_skill_for_message(
-            user_message=user_message,
-            selected_skills=selected_skills,
-            attachment_descriptors=tuple(
-                AttachmentDescriptor(
-                    filename=str(getattr(attachment, "filename", "") or ""),
-                    content_type=str(getattr(attachment, "content_type", "") or ""),
-                )
-                for attachment in attachments
-            ),
-            skill_registry=self._skill_registry,
-            client=self._client,
-            model=settings.SKILL_SELECTOR_MODEL or settings.LITE_MODEL,
+        # Skill matching via the shared activation controller
+        self._skill_controller.begin_turn(
+            prompt_assembly=prompt_assembly,
+            registry=self._registry,
         )
-        if matched is not None:
-            self._auto_injected_skill = matched.metadata.name
-            explicit_skill_name = next((s for s in selected_skills if s.strip()), None)
-            source = "explicit" if explicit_skill_name is not None else "auto"
-
-            # Replace ActivateSkill tool with active skill name
-            from agent.tools.local.activate_skill import ActivateSkill
-
-            effective_registry = effective_registry.replace_tool(
-                ActivateSkill(
-                    skill_registry=self._skill_registry,
-                    active_skill_name=matched.metadata.name,
+        try:
+            activation, _matched = (
+                await self._skill_controller.match_and_activate_turn_start(
+                    user_message=user_message,
+                    selected_skills=selected_skills,
+                    prompt_assembly=prompt_assembly,
+                    registry=self._registry,
+                    cache_prompt=cache_prompt,
+                    attachments=attachments,
                 )
             )
-            self._turn_unfiltered_registry = effective_registry
-            try:
-                await prepare_skill_for_turn(
-                    executor=self._executor,
-                    skill=matched,
-                    emitter=self._emitter,
-                    source=source,
-                    install_dependencies=lambda: install_skill_dependencies_for_turn(
-                        self._executor,
-                        matched.metadata.dependencies,
-                        self._emitter,
-                        context="planner",
-                        skill_name=matched.metadata.name,
-                        source=source,
-                        raise_on_error=True,
-                    ),
-                )
-            except Exception as exc:
-                await self._emitter.emit(
-                    EventType.TASK_ERROR,
-                    {
-                        "error": str(exc),
-                        "code": "skill_setup",
-                        "retryable": False,
-                    },
-                )
-                return f"Error: {exc}"
-            prompt_assembly = prompt_assembly.with_volatile_sections(
-                build_skill_prompt_content(matched),
+        except Exception as exc:
+            await self._emitter.emit(
+                EventType.TASK_ERROR,
+                {"error": str(exc), "code": "skill_setup", "retryable": False},
             )
-
-            # Filter tools by allowed_tools
-            if matched.metadata.allowed_tools:
-                allowed_names, allowed_tags = split_allowed_tools(
-                    matched.metadata.allowed_tools,
-                    preserved_names=_PLANNER_PRESERVED_TOOL_NAMES,
-                )
-                set_allowed_tools = getattr(self._executor, "set_allowed_tools", None)
-                if callable(set_allowed_tools):
-                    set_allowed_tools(allowed_names, allowed_tags)
-                effective_registry = effective_registry.filter_by_names_or_tags(
-                    allowed_names, allowed_tags
-                )
-        else:
-            self._turn_unfiltered_registry = effective_registry
+            return f"Error: {exc}"
+        prompt_assembly = activation.prompt_assembly
+        tools = activation.tools
 
         uploaded_paths: tuple[str, ...] = ()
         if attachments:
@@ -713,7 +565,6 @@ class PlannerOrchestrator:
         self._state = replace(self._state, completed=False, error=None, iteration=0)
         self._turn_artifact_ids = []
 
-        tools = effective_registry.to_anthropic_tools(cache_breakpoint=cache_prompt)
         model = get_settings().PLANNING_MODEL
 
         try:
@@ -736,15 +587,16 @@ class PlannerOrchestrator:
                     iteration_prompt_assembly.rendered,
                 )
 
-                if self._pending_mid_turn_update is not None:
-                    prompt_assembly, effective_registry, tools = (
-                        self._pending_mid_turn_update
+                update = self._pending_mid_turn_update
+                self._pending_mid_turn_update = None
+                if update is None:
+                    update = await self._skill_controller.check_mid_turn_from_messages(
+                        list(self._state.messages),
+                        cache_prompt=cache_prompt,
                     )
-                    self._pending_mid_turn_update = None
-
-                updated = await self._check_mid_turn_skill_activation()
-                if updated is not None:
-                    prompt_assembly, effective_registry, tools = updated
+                if update is not None:
+                    prompt_assembly = update.prompt_assembly
+                    tools = update.tools
         finally:
             await self._cleanup_sub_agents()
 
@@ -763,42 +615,12 @@ class PlannerOrchestrator:
         effective_prompt = system_prompt_text or render_system_prompt(effective_system)
 
         # Compact history before the LLM call if needed
-        if self._observer.should_compact(state.messages, effective_prompt):
-            compaction_context = ContextCompactionContext(
-                conversation_id=self._conversation_id,
-                user_id=self._hook_user_id,
-                messages=state.messages,
-                effective_prompt=effective_prompt,
-                profile_name=self._compaction_profile.name,
-                metadata={
-                    "memory_flush": self._compaction_profile.memory_flush,
-                    "persistent_store": self._persistent_store,
-                },
-            )
-            await self._conversation_hooks.before_context_compaction(
-                compaction_context,
-            )
-            compacted = await self._observer.compact(state.messages, effective_prompt)
-            summary_text = compaction_summary_for_persistence(compacted)
-            await self._emitter.emit(
-                EventType.CONTEXT_COMPACTED,
-                {
-                    "original_messages": len(state.messages),
-                    "compacted_messages": len(compacted),
-                    "summary_text": summary_text,
-                    "summary_scope": "conversation",
-                    "compaction_profile": self._compaction_profile.name,
-                },
-                iteration=state.iteration,
-            )
-            await self._conversation_hooks.after_context_compaction(
-                compaction_context,
-                ContextCompactionResult(
-                    original_message_count=len(state.messages),
-                    compacted_messages=compacted,
-                    summary_text=summary_text,
-                ),
-            )
+        compacted, did_compact = await self._compaction_step.maybe_compact(
+            state.messages,
+            effective_prompt,
+            iteration=state.iteration,
+        )
+        if did_compact:
             state = replace(state, messages=compacted)
 
         await self._emitter.emit(
@@ -835,12 +657,14 @@ class PlannerOrchestrator:
             return state.mark_completed()
 
         async def _post_tool_callback(tc: Any, result: Any) -> None:
-            skill_name = self._requested_skill_name_from_tool_call(tc.name, tc.input)
+            skill_name = self._skill_controller.requested_skill_name(tc.name, tc.input)
             if skill_name is None or not result.success:
                 return
-            updated = await self._apply_mid_turn_skill_activation(
+            updated = await self._skill_controller.apply_mid_turn(
                 skill_name,
                 tool_id=tc.id,
+                messages=list(state.messages),
+                cache_prompt=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False),
             )
             if updated is not None:
                 self._pending_mid_turn_update = updated
@@ -870,71 +694,6 @@ class PlannerOrchestrator:
             return state.mark_completed(self._task_complete_summary)
 
         return state
-
-    async def _check_mid_turn_skill_activation(
-        self,
-    ) -> tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None:
-        """Detect a successful mid-turn skill activation and enforce constraints."""
-        if self._skill_registry is None:
-            return None
-
-        last_assistant = None
-        for msg in reversed(self._state.messages):
-            if msg.get("role") == "assistant":
-                last_assistant = msg
-                break
-
-        if last_assistant is None:
-            return None
-
-        content = last_assistant.get("content")
-        if not isinstance(content, list):
-            return None
-
-        activated_name: str | None = None
-        tool_id: str | None = None
-        for block in content:
-            if not isinstance(block, dict) or block.get("type") != "tool_use":
-                continue
-            block_name = block.get("name")
-            if block_name == "activate_skill":
-                skill_input = block.get("input", {})
-                activated_name = skill_input.get("name")
-                tool_id = block.get("id")
-                break
-            if (
-                isinstance(block_name, str)
-                and self._skill_registry.find_by_name(block_name) is not None
-            ):
-                activated_name = block_name
-                tool_id = block.get("id")
-                break
-
-        if not activated_name:
-            return None
-
-        if tool_id is not None and tool_id in self._processed_skill_activation_tool_ids:
-            return None
-
-        if tool_id is not None and tool_use_had_error_result(
-            list(self._state.messages),
-            tool_id,
-        ):
-            return None
-
-        if activated_name == self._auto_injected_skill:
-            await emit_redundant_skill_activation(
-                self._emitter,
-                skill_name=activated_name,
-                tool_id=tool_id,
-                messages=list(self._state.messages),
-            )
-            return None
-
-        return await self._apply_mid_turn_skill_activation(
-            activated_name,
-            tool_id=tool_id,
-        )
 
     async def _call_llm(
         self,
@@ -1055,42 +814,13 @@ class PlannerOrchestrator:
 
     async def _finalize(self, state: AgentState) -> str:
         """Emit final event and return the result text."""
-        if self._cancel_event.is_set():
-            self._cancel_event.clear()
-            current_turn_messages = self._current_turn_messages_for_cancel()
-            final_text = extract_final_text_from_messages(current_turn_messages)
-            await self._emitter.emit(
-                EventType.TURN_CANCELLED,
-                {"result": final_text},
-            )
-            self._state = replace(
-                self._state,
-                messages=self._current_turn_base_messages,
-                completed=False,
-                error=None,
-            )
-            return final_text
-
-        if state.error:
-            err_msg = state.error
-            retryable = "LLM call failed" in err_msg
-            code = "llm_error" if retryable else "agent_error"
-            if is_content_policy_error(err_msg):
-                code = "content_policy"
-                retryable = False
-            if "maximum iterations" in err_msg.lower():
-                code = "max_iterations"
-                retryable = False
-            await self._emitter.emit(
-                EventType.TASK_ERROR,
-                {"error": err_msg, "code": code, "retryable": retryable},
-            )
-            return f"Error: {state.error}"
-
-        final_text = extract_final_text(state)
-        await self._emitter.emit(
-            EventType.TURN_COMPLETE,
-            {"result": final_text, "artifact_ids": self._turn_artifact_ids},
+        final_text, self._state = await finalize_conversation_turn(
+            state=state,
+            cancel_event=self._cancel_event,
+            current_turn_messages=self._current_turn_messages_for_cancel(),
+            base_messages=self._current_turn_base_messages,
+            emitter=self._emitter,
+            artifact_ids=self._turn_artifact_ids,
         )
         return final_text
 

--- a/backend/agent/runtime/skill_activation.py
+++ b/backend/agent/runtime/skill_activation.py
@@ -1,0 +1,377 @@
+"""Shared skill-activation controller for agent runtimes.
+
+The single-agent orchestrator, planner, and task-agent runner all need the
+same behavior around skills: match a skill at the start of a turn, stage it,
+inject its prompt content, optionally restrict the tool registry, and react
+to ``activate_skill`` calls mid-turn. This module owns that behavior once so
+the three loops do not each re-implement it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from loguru import logger
+
+from agent.llm.client import AnthropicClient
+from agent.runtime.prompting import PromptAssembly
+from agent.runtime.skill_install import install_skill_dependencies_for_turn
+from agent.runtime.skill_runtime import split_allowed_tools
+from agent.runtime.skill_selector import (
+    AttachmentDescriptor,
+    select_skill_for_message,
+)
+from agent.runtime.skill_setup import (
+    build_skill_prompt_content,
+    emit_redundant_skill_activation,
+    prepare_skill_for_turn,
+    tool_use_had_error_result,
+)
+from agent.skills.loader import SkillRegistry
+from agent.skills.models import SkillContent
+from agent.tools.executor import ToolExecutor
+from agent.tools.registry import ToolRegistry
+from api.events import EventEmitter
+from config.settings import get_settings
+
+
+def _attachment_descriptors(
+    attachments: tuple[Any, ...],
+) -> tuple[AttachmentDescriptor, ...]:
+    """Build skill-selector descriptors from turn attachments."""
+    return tuple(
+        AttachmentDescriptor(
+            filename=str(getattr(attachment, "filename", "") or ""),
+            content_type=str(getattr(attachment, "content_type", "") or ""),
+        )
+        for attachment in attachments
+    )
+
+
+@dataclass(frozen=True)
+class SkillActivation:
+    """Immutable result of activating (or re-resolving) a skill for a turn.
+
+    Carries the effective prompt assembly, the effective tool registry, and
+    the provider-ready tool payload that the loop should use going forward.
+    """
+
+    prompt_assembly: PromptAssembly
+    registry: ToolRegistry
+    tools: list[dict[str, Any]]
+
+
+class SkillActivationController:
+    """Owns turn-start and mid-turn skill activation for one runtime loop.
+
+    A single instance is reused across turns; call :meth:`begin_turn` at the
+    start of every turn to reset per-turn state. The controller mutates the
+    provided executor (staging, allowed-tool restrictions) and emits skill
+    lifecycle events through the shared emitter.
+    """
+
+    def __init__(
+        self,
+        *,
+        skill_registry: SkillRegistry | None,
+        executor: ToolExecutor,
+        emitter: EventEmitter,
+        client: AnthropicClient,
+        install_context: str,
+        preserved_tool_names: tuple[str, ...] = (),
+    ) -> None:
+        self._skill_registry = skill_registry
+        self._executor = executor
+        self._emitter = emitter
+        self._client = client
+        self._install_context = install_context
+        self._preserved_tool_names = preserved_tool_names
+
+        self._auto_injected_skill: str | None = None
+        self._turn_prompt_assembly: PromptAssembly | None = None
+        self._turn_unfiltered_registry: ToolRegistry | None = None
+        self._processed_skill_activation_tool_ids: set[str] = set()
+
+    @property
+    def auto_injected_skill(self) -> str | None:
+        """Return the skill auto-activated for the current turn, if any."""
+        return self._auto_injected_skill
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when a skill registry is wired up."""
+        return self._skill_registry is not None
+
+    def begin_turn(
+        self,
+        *,
+        prompt_assembly: PromptAssembly,
+        registry: ToolRegistry,
+    ) -> None:
+        """Reset per-turn state ahead of turn-start matching."""
+        self._auto_injected_skill = None
+        self._processed_skill_activation_tool_ids = set()
+        self._turn_prompt_assembly = prompt_assembly
+        self._turn_unfiltered_registry = registry
+
+    async def match_and_activate_turn_start(
+        self,
+        *,
+        user_message: str,
+        selected_skills: tuple[str, ...],
+        prompt_assembly: PromptAssembly,
+        registry: ToolRegistry,
+        cache_prompt: bool,
+        attachments: tuple[Any, ...] = (),
+    ) -> tuple[SkillActivation, SkillContent | None]:
+        """Resolve and activate the best skill for the start of a turn.
+
+        Always returns a :class:`SkillActivation` describing the tools/prompt
+        the loop should use, plus the matched skill (or ``None``). Raises if a
+        matched skill fails to stage so the caller can surface a setup error.
+        """
+        self._turn_unfiltered_registry = registry
+        if self._skill_registry is None:
+            return (
+                SkillActivation(
+                    prompt_assembly=prompt_assembly,
+                    registry=registry,
+                    tools=registry.to_anthropic_tools(cache_breakpoint=cache_prompt),
+                ),
+                None,
+            )
+
+        settings = get_settings()
+        matched = await select_skill_for_message(
+            user_message=user_message,
+            selected_skills=selected_skills,
+            attachment_descriptors=_attachment_descriptors(attachments),
+            skill_registry=self._skill_registry,
+            client=self._client,
+            model=settings.SKILL_SELECTOR_MODEL or settings.LITE_MODEL,
+        )
+        if matched is None:
+            return (
+                SkillActivation(
+                    prompt_assembly=prompt_assembly,
+                    registry=registry,
+                    tools=registry.to_anthropic_tools(cache_breakpoint=cache_prompt),
+                ),
+                None,
+            )
+
+        self._auto_injected_skill = matched.metadata.name
+        explicit_skill_name = next((s for s in selected_skills if s.strip()), None)
+        source = "explicit" if explicit_skill_name is not None else "auto"
+
+        registry = self._replace_activate_skill_tool(registry, matched.metadata.name)
+        self._turn_unfiltered_registry = registry
+
+        await prepare_skill_for_turn(
+            executor=self._executor,
+            skill=matched,
+            emitter=self._emitter,
+            source=source,
+            install_dependencies=lambda: install_skill_dependencies_for_turn(
+                self._executor,
+                matched.metadata.dependencies,
+                self._emitter,
+                context=self._install_context,
+                skill_name=matched.metadata.name,
+                source=source,
+                raise_on_error=True,
+            ),
+        )
+
+        prompt_assembly = prompt_assembly.with_volatile_sections(
+            build_skill_prompt_content(matched),
+        )
+        effective_registry = self._apply_allowed_tools(registry, matched)
+        return (
+            SkillActivation(
+                prompt_assembly=prompt_assembly,
+                registry=effective_registry,
+                tools=effective_registry.to_anthropic_tools(
+                    cache_breakpoint=cache_prompt
+                ),
+            ),
+            matched,
+        )
+
+    def requested_skill_name(
+        self,
+        tool_call_name: str,
+        tool_input: dict[str, Any],
+    ) -> str | None:
+        """Map a tool call to the skill name it would activate, if any."""
+        if self._skill_registry is None:
+            return None
+        if tool_call_name == "activate_skill":
+            name = tool_input.get("name")
+            return name if isinstance(name, str) and name else None
+        if self._skill_registry.find_by_name(tool_call_name) is not None:
+            return tool_call_name
+        return None
+
+    async def apply_mid_turn(
+        self,
+        skill_name: str,
+        *,
+        tool_id: str | None,
+        messages: list[dict[str, Any]],
+        cache_prompt: bool,
+    ) -> SkillActivation | None:
+        """Activate *skill_name* mid-turn, returning new prompt/tools or None."""
+        if self._skill_registry is None or self._turn_prompt_assembly is None:
+            return None
+
+        if tool_id is not None and tool_id in self._processed_skill_activation_tool_ids:
+            return None
+
+        if skill_name == self._auto_injected_skill:
+            await emit_redundant_skill_activation(
+                self._emitter,
+                skill_name=skill_name,
+                tool_id=tool_id,
+                messages=messages,
+            )
+            if tool_id is not None:
+                self._processed_skill_activation_tool_ids.add(tool_id)
+            return None
+
+        skill = self._skill_registry.find_by_name(skill_name)
+        if skill is None:
+            return None
+
+        self._auto_injected_skill = skill.metadata.name
+        prompt_assembly = self._turn_prompt_assembly.with_volatile_sections(
+            build_skill_prompt_content(skill),
+        )
+
+        base_registry = self._turn_unfiltered_registry
+        updated_registry = self._replace_activate_skill_tool(
+            base_registry, skill.metadata.name
+        )
+
+        reset_allowed_tools = getattr(self._executor, "reset_allowed_tools", None)
+        if callable(reset_allowed_tools):
+            reset_allowed_tools()
+
+        await prepare_skill_for_turn(
+            executor=self._executor,
+            skill=skill,
+            emitter=self._emitter,
+            source="mid_turn",
+            install_dependencies=lambda: install_skill_dependencies_for_turn(
+                self._executor,
+                skill.metadata.dependencies,
+                self._emitter,
+                context=f"{self._install_context}_mid_turn",
+                skill_name=skill.metadata.name,
+                source="mid_turn",
+                raise_on_error=True,
+            ),
+        )
+
+        updated_registry = self._apply_allowed_tools(updated_registry, skill)
+        if tool_id is not None:
+            self._processed_skill_activation_tool_ids.add(tool_id)
+        logger.info(
+            "mid_turn_skill_activated context={} name={}",
+            self._install_context,
+            skill.metadata.name,
+        )
+        return SkillActivation(
+            prompt_assembly=prompt_assembly,
+            registry=updated_registry,
+            tools=updated_registry.to_anthropic_tools(cache_breakpoint=cache_prompt),
+        )
+
+    async def check_mid_turn_from_messages(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        cache_prompt: bool,
+    ) -> SkillActivation | None:
+        """Detect an ``activate_skill`` call in the latest assistant message."""
+        if self._skill_registry is None:
+            return None
+
+        last_assistant = None
+        for msg in reversed(messages):
+            if msg.get("role") == "assistant":
+                last_assistant = msg
+                break
+        if last_assistant is None:
+            return None
+
+        content = last_assistant.get("content")
+        if not isinstance(content, list):
+            return None
+
+        activated_name, tool_id = self._scan_activation_block(content)
+        if not activated_name:
+            return None
+        if tool_id is not None and tool_id in self._processed_skill_activation_tool_ids:
+            return None
+        if tool_id is not None and tool_use_had_error_result(messages, tool_id):
+            return None
+
+        return await self.apply_mid_turn(
+            activated_name,
+            tool_id=tool_id,
+            messages=messages,
+            cache_prompt=cache_prompt,
+        )
+
+    def _scan_activation_block(
+        self,
+        content: list[Any],
+    ) -> tuple[str | None, str | None]:
+        """Return the (skill_name, tool_id) of the first activation tool_use."""
+        assert self._skill_registry is not None
+        for block in content:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            block_name = block.get("name")
+            if block_name == "activate_skill":
+                skill_input = block.get("input", {})
+                return skill_input.get("name"), block.get("id")
+            if (
+                isinstance(block_name, str)
+                and self._skill_registry.find_by_name(block_name) is not None
+            ):
+                return block_name, block.get("id")
+        return None, None
+
+    def _replace_activate_skill_tool(
+        self,
+        registry: ToolRegistry,
+        active_skill_name: str,
+    ) -> ToolRegistry:
+        from agent.tools.local.activate_skill import ActivateSkill
+
+        return registry.replace_tool(
+            ActivateSkill(
+                skill_registry=self._skill_registry,
+                active_skill_name=active_skill_name,
+            )
+        )
+
+    def _apply_allowed_tools(
+        self,
+        registry: ToolRegistry,
+        skill: SkillContent,
+    ) -> ToolRegistry:
+        """Restrict *registry* and the executor to a skill's allowed tools."""
+        if not skill.metadata.allowed_tools:
+            return registry
+        allowed_names, allowed_tags = split_allowed_tools(
+            skill.metadata.allowed_tools,
+            preserved_names=self._preserved_tool_names,
+        )
+        set_allowed_tools = getattr(self._executor, "set_allowed_tools", None)
+        if callable(set_allowed_tools):
+            set_allowed_tools(allowed_names, allowed_tags)
+        return registry.filter_by_names_or_tags(allowed_names, allowed_tags)

--- a/backend/agent/runtime/task_runner.py
+++ b/backend/agent/runtime/task_runner.py
@@ -4,23 +4,21 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Any, Literal
 
 from agent.context.profiles import CompactionProfile, resolve_compaction_profile
 from agent.llm.client import (
     AnthropicClient,
-    SystemPrompt,
-    format_llm_failure,
+    LLMResponse,
     render_system_prompt,
 )
 from agent.runtime.helpers import (
-    apply_response_to_state,
     extract_final_text,
-    process_tool_calls,
 )
 from agent.context.compaction import Observer
 from agent.context.compaction_step import CompactionStep
+from agent.runtime.engine import AgentLoop, LoopConfig, LoopPolicy
 from agent.runtime.orchestrator import AgentState
 from agent.runtime.system_prompt_sections import (
     build_memory_aware_system_prompt_sections,
@@ -30,8 +28,8 @@ from agent.runtime.prompting import PromptAssembly
 from agent.skills.loader import SkillRegistry
 from agent.tools.executor import ToolExecutor
 from agent.tools.registry import ToolRegistry
-from api.events import EventEmitter, EventType
-from config.settings import Settings, get_settings
+from api.events import EventEmitter
+from config.settings import get_settings
 from loguru import logger
 
 
@@ -168,7 +166,7 @@ def _build_system_prompt(
     )
 
 
-class TaskAgentRunner:
+class TaskAgentRunner(LoopPolicy):
     """Runs a focused sub-task using a ReAct loop."""
 
     def __init__(
@@ -252,8 +250,15 @@ class TaskAgentRunner:
         self._output_tokens = 0
         self._shared_tools = shared_tools
         self._shared_tools_fingerprint = shared_tools_fingerprint
-        self._pending_mid_turn_update: SkillActivation | None = None
         self._completed_via_task_complete = False
+        self._loop = AgentLoop(
+            client=claude_client,
+            emitter=event_emitter,
+            executor=tool_executor,
+            compaction_step=self._compaction_step,
+            skill_controller=self._skill_controller,
+            policy=self,
+        )
 
     def _increment_compaction_count(self) -> None:
         """Record that a context compaction ran (metrics)."""
@@ -345,7 +350,6 @@ class TaskAgentRunner:
         self._output_tokens = 0
         self._task_complete_summary = None
         self._handoff_request = None
-        self._pending_mid_turn_update = None
         self._completed_via_task_complete = False
 
     def _build_metrics(self, started_at: float) -> AgentRunMetrics:
@@ -361,7 +365,6 @@ class TaskAgentRunner:
 
     async def _execute_loop(self) -> str:
         """Run the ReAct loop until completion or error."""
-        settings = get_settings()
         state = AgentState().add_message(
             {"role": "user", "content": self._config.task_description},
         )
@@ -384,27 +387,12 @@ class TaskAgentRunner:
         prompt_assembly = activation.prompt_assembly
         tools = self._tools_for_registry(activation, cache_prompt)
 
-        while not state.completed and state.error is None:
-            state = state.increment_iteration()
-            self._iterations = state.iteration
-            state = await self._run_iteration(
-                state,
-                tools,
-                settings,
-                prompt_assembly.system_with_cache_control(cache_prompt),
-                prompt_assembly.rendered,
-            )
-
-            update = self._pending_mid_turn_update
-            self._pending_mid_turn_update = None
-            if update is None:
-                update = await self._skill_controller.check_mid_turn_from_messages(
-                    list(state.messages),
-                    cache_prompt=cache_prompt,
-                )
-            if update is not None:
-                prompt_assembly = update.prompt_assembly
-                tools = self._tools_for_registry(update, cache_prompt)
+        state = await self._loop.run_turn(
+            state=state,
+            prompt_assembly=prompt_assembly,
+            tools=tools,
+            cache_prompt=cache_prompt,
+        )
 
         if state.error:
             raise RuntimeError(state.error)
@@ -425,108 +413,45 @@ class TaskAgentRunner:
             return self._shared_tools
         return activation.tools
 
-    async def _run_iteration(
-        self,
-        state: AgentState,
-        tools: list[dict[str, Any]],
-        settings: Settings,
-        system_prompt: SystemPrompt,
-        system_prompt_text: str,
-    ) -> AgentState:
-        """Run a single iteration of the task agent loop."""
-        # Compact history before the LLM call if needed
-        compacted, did_compact = await self._compaction_step.maybe_compact(
-            state.messages,
-            system_prompt_text,
+    @property
+    def loop_config(self) -> LoopConfig:
+        settings = get_settings()
+        return LoopConfig(
+            max_iterations=self._max_iterations,
+            model=self._config.model or settings.TASK_MODEL,
+            emit_iteration_start=False,
+            emit_llm_response=False,
+            agent_id=self._agent_id,
+            debug_label="task_runner",
+            debug_logging=getattr(settings, "AGENT_DEBUG_LOGGING", False),
         )
-        if did_compact:
-            state = replace(state, messages=compacted)
 
-        if state.iteration > self._max_iterations:
-            return state.mark_error(
-                f"Exceeded maximum iterations ({self._max_iterations})",
-            )
+    def loop_on_iteration_begin(self, state: AgentState) -> None:
+        self._iterations = state.iteration
 
-        llm_model = self._config.model or settings.TASK_MODEL
-        debug_logging_enabled = getattr(settings, "AGENT_DEBUG_LOGGING", False)
-        try:
-            if debug_logging_enabled:
-                logger.debug(
-                    "task_runner_llm_call agent_id={} model={} iteration={} messages={} tools={}",
-                    self._agent_id,
-                    llm_model,
-                    state.iteration,
-                    len(state.messages),
-                    len(tools),
-                )
+    def loop_stop_processing(self) -> bool:
+        return (
+            self._task_complete_summary is not None
+            or self._handoff_request is not None
+        )
 
-            async def _on_text_delta(delta: str) -> None:
-                await self._emitter.emit(
-                    EventType.TEXT_DELTA,
-                    {"delta": delta, "agent_id": self._agent_id},
-                    iteration=state.iteration,
-                )
-
-            response = await self._client.create_message_stream(
-                system=system_prompt,
-                messages=list(state.messages),
-                tools=tools if tools else None,
-                model=llm_model,
-                on_text_delta=_on_text_delta,
-            )
-        except Exception as exc:
-            if debug_logging_enabled:
-                logger.debug(
-                    "task_runner_llm_exception agent_id={} model={} iteration={} error_type={}",
-                    self._agent_id,
-                    llm_model,
-                    state.iteration,
-                    type(exc).__name__,
-                )
-            logger.error("llm_call_failed model={} error={}", llm_model, exc)
-            return state.mark_error(format_llm_failure(exc))
-
-        state = apply_response_to_state(state, response)
+    async def loop_on_llm_usage(self, response: LLMResponse) -> None:
         self._input_tokens += response.usage.input_tokens
         self._output_tokens += response.usage.output_tokens
 
-        if not response.tool_calls:
-            return state.mark_completed()
-
-        async def _post_tool_callback(tc: Any, result: Any) -> None:
-            skill_name = self._skill_controller.requested_skill_name(tc.name, tc.input)
-            if skill_name is None or not result.success:
-                return
-            updated = await self._skill_controller.apply_mid_turn(
-                skill_name,
-                tool_id=tc.id,
-                messages=list(state.messages),
-                cache_prompt=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False),
-            )
-            if updated is not None:
-                self._pending_mid_turn_update = updated
-
-        try:
-            tool_result = await process_tool_calls(
-                state=state,
-                tool_calls=response.tool_calls,
-                executor=self._executor,
-                emitter=self._emitter,
-                agent_id=self._agent_id,
-                stop_check=lambda: (
-                    self._task_complete_summary is not None
-                    or self._handoff_request is not None
-                ),
-                post_tool_callback=_post_tool_callback,
-            )
-        except Exception as exc:
-            return state.mark_error(str(exc))
-        state = tool_result.state
+    async def loop_on_tools_processed(
+        self,
+        state: AgentState,
+        response: LLMResponse,
+        tool_result: Any,
+    ) -> AgentState:
         self._tool_call_count += tool_result.processed_count
         for artifact_id in tool_result.artifact_ids:
             if artifact_id not in self._artifact_ids:
                 self._artifact_ids.append(artifact_id)
+        return state
 
+    async def loop_on_task_complete(self, state: AgentState) -> AgentState | None:
         if self._task_complete_summary is not None:
             return state.mark_completed(self._task_complete_summary)
 
@@ -541,4 +466,4 @@ class TaskAgentRunner:
             self._handoff_request = handoff_with_messages
             return state.mark_completed("Handing off to specialist agent.")
 
-        return state
+        return None

--- a/backend/agent/runtime/task_runner.py
+++ b/backend/agent/runtime/task_runner.py
@@ -19,21 +19,14 @@ from agent.runtime.helpers import (
     extract_final_text,
     process_tool_calls,
 )
-from agent.context.compaction import Observer, compaction_summary_for_persistence
+from agent.context.compaction import Observer
+from agent.context.compaction_step import CompactionStep
 from agent.runtime.orchestrator import AgentState
 from agent.runtime.system_prompt_sections import (
     build_memory_aware_system_prompt_sections,
 )
-from agent.runtime.skill_install import install_skill_dependencies_for_turn
-from agent.runtime.skill_runtime import split_allowed_tools
-from agent.runtime.skill_setup import (
-    build_skill_prompt_content,
-    emit_redundant_skill_activation,
-    prepare_skill_for_turn,
-    tool_use_had_error_result,
-)
+from agent.runtime.skill_activation import SkillActivation, SkillActivationController
 from agent.runtime.prompting import PromptAssembly
-from agent.runtime.skill_selector import select_skill_for_message
 from agent.skills.loader import SkillRegistry
 from agent.tools.executor import ToolExecutor
 from agent.tools.registry import ToolRegistry
@@ -232,8 +225,23 @@ class TaskAgentRunner:
             ),
             settings=settings,
         )
-        self._turn_prompt_assembly = PromptAssembly.from_system(self._system_prompt)
-        self._auto_injected_skill: str | None = None
+        self._skill_controller = SkillActivationController(
+            skill_registry=skill_registry,
+            executor=tool_executor,
+            emitter=event_emitter,
+            client=claude_client,
+            install_context="task_runner",
+            preserved_tool_names=_TASK_AGENT_PRESERVED_TOOL_NAMES,
+        )
+        self._compaction_step = CompactionStep(
+            observer=self._observer,
+            profile=self._compaction_profile,
+            emitter=event_emitter,
+            summary_scope="task_agent",
+            agent_id=agent_id,
+            emit_iteration=False,
+            on_compacted=self._increment_compaction_count,
+        )
         self._task_complete_summary: str | None = None
         self._handoff_request: HandoffRequest | None = None
         self._artifact_ids: list[str] = []
@@ -244,12 +252,12 @@ class TaskAgentRunner:
         self._output_tokens = 0
         self._shared_tools = shared_tools
         self._shared_tools_fingerprint = shared_tools_fingerprint
-        self._turn_unfiltered_registry = tool_registry
-        self._pending_mid_turn_update: (
-            tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None
-        ) = None
-        self._processed_skill_activation_tool_ids: set[str] = set()
+        self._pending_mid_turn_update: SkillActivation | None = None
         self._completed_via_task_complete = False
+
+    def _increment_compaction_count(self) -> None:
+        """Record that a context compaction ran (metrics)."""
+        self._context_compaction_count += 1
 
     async def on_task_complete(self, summary: str) -> None:
         """Callback for the task_complete tool."""
@@ -338,7 +346,6 @@ class TaskAgentRunner:
         self._task_complete_summary = None
         self._handoff_request = None
         self._pending_mid_turn_update = None
-        self._processed_skill_activation_tool_ids = set()
         self._completed_via_task_complete = False
 
     def _build_metrics(self, started_at: float) -> AgentRunMetrics:
@@ -352,105 +359,6 @@ class TaskAgentRunner:
             output_tokens=self._output_tokens,
         )
 
-    def _requested_skill_name_from_tool_call(
-        self,
-        tool_call_name: str,
-        tool_input: dict[str, Any],
-    ) -> str | None:
-        if self._skill_registry is None:
-            return None
-        if tool_call_name == "activate_skill":
-            name = tool_input.get("name")
-            return name if isinstance(name, str) and name else None
-        if self._skill_registry.find_by_name(tool_call_name) is not None:
-            return tool_call_name
-        return None
-
-    async def _apply_mid_turn_skill_activation(
-        self,
-        skill_name: str,
-        *,
-        tool_id: str | None,
-        messages: list[dict[str, Any]],
-    ) -> tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None:
-        if self._skill_registry is None:
-            return None
-
-        if tool_id is not None and tool_id in self._processed_skill_activation_tool_ids:
-            return None
-
-        if skill_name == self._auto_injected_skill:
-            await emit_redundant_skill_activation(
-                self._emitter,
-                skill_name=skill_name,
-                tool_id=tool_id,
-                messages=messages,
-            )
-            if tool_id is not None:
-                self._processed_skill_activation_tool_ids.add(tool_id)
-            return None
-
-        skill = self._skill_registry.find_by_name(skill_name)
-        if skill is None:
-            return None
-
-        self._auto_injected_skill = skill.metadata.name
-        prompt_assembly = self._turn_prompt_assembly.with_volatile_sections(
-            build_skill_prompt_content(skill),
-        )
-
-        from agent.tools.local.activate_skill import ActivateSkill
-
-        updated_registry = self._turn_unfiltered_registry.replace_tool(
-            ActivateSkill(
-                skill_registry=self._skill_registry,
-                active_skill_name=skill.metadata.name,
-            )
-        )
-
-        reset_allowed_tools = getattr(self._executor, "reset_allowed_tools", None)
-        if callable(reset_allowed_tools):
-            reset_allowed_tools()
-
-        await prepare_skill_for_turn(
-            executor=self._executor,
-            skill=skill,
-            emitter=self._emitter,
-            source="mid_turn",
-            install_dependencies=lambda: install_skill_dependencies_for_turn(
-                self._executor,
-                skill.metadata.dependencies,
-                self._emitter,
-                context="task_runner_mid_turn",
-                skill_name=skill.metadata.name,
-                source="mid_turn",
-                raise_on_error=True,
-            ),
-        )
-
-        if skill.metadata.allowed_tools:
-            allowed_names, allowed_tags = split_allowed_tools(
-                skill.metadata.allowed_tools,
-                preserved_names=_TASK_AGENT_PRESERVED_TOOL_NAMES,
-            )
-            set_allowed_tools = getattr(self._executor, "set_allowed_tools", None)
-            if callable(set_allowed_tools):
-                set_allowed_tools(allowed_names, allowed_tags)
-            updated_registry = updated_registry.filter_by_names_or_tags(
-                allowed_names, allowed_tags
-            )
-
-        if tool_id is not None:
-            self._processed_skill_activation_tool_ids.add(tool_id)
-        logger.info("task_runner_mid_turn_skill_activated name={}", skill.metadata.name)
-        return (
-            prompt_assembly,
-            updated_registry,
-            updated_registry.to_anthropic_tools(
-                cache_breakpoint=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False)
-            ),
-        )
-
     async def _execute_loop(self) -> str:
         """Run the ReAct loop until completion or error."""
         settings = get_settings()
@@ -459,71 +367,22 @@ class TaskAgentRunner:
         )
         cache_prompt = getattr(get_settings(), "PROMPT_CACHE_ENABLED", False)
         prompt_assembly = PromptAssembly.from_system(self._system_prompt)
-        effective_registry = self._registry
-        self._turn_unfiltered_registry = effective_registry
-        self._auto_injected_skill = None
 
-        matched = await select_skill_for_message(
-            user_message=self._config.task_description,
-            selected_skills=(),
-            skill_registry=self._skill_registry,
-            client=self._client,
-            model=settings.SKILL_SELECTOR_MODEL or settings.LITE_MODEL,
+        self._skill_controller.begin_turn(
+            prompt_assembly=prompt_assembly,
+            registry=self._registry,
         )
-        if matched is not None:
-            self._auto_injected_skill = matched.metadata.name
-            self._turn_prompt_assembly = prompt_assembly
-
-            from agent.tools.local.activate_skill import ActivateSkill
-
-            effective_registry = effective_registry.replace_tool(
-                ActivateSkill(
-                    skill_registry=self._skill_registry,
-                    active_skill_name=matched.metadata.name,
-                )
+        activation, _matched = (
+            await self._skill_controller.match_and_activate_turn_start(
+                user_message=self._config.task_description,
+                selected_skills=(),
+                prompt_assembly=prompt_assembly,
+                registry=self._registry,
+                cache_prompt=cache_prompt,
             )
-            self._turn_unfiltered_registry = effective_registry
-            await prepare_skill_for_turn(
-                executor=self._executor,
-                skill=matched,
-                emitter=self._emitter,
-                source="auto",
-                install_dependencies=lambda: install_skill_dependencies_for_turn(
-                    self._executor,
-                    matched.metadata.dependencies,
-                    self._emitter,
-                    context="task_runner",
-                    skill_name=matched.metadata.name,
-                    source="auto",
-                    raise_on_error=True,
-                ),
-            )
-            prompt_assembly = prompt_assembly.with_volatile_sections(
-                build_skill_prompt_content(matched),
-            )
-
-            if matched.metadata.allowed_tools:
-                allowed_names, allowed_tags = split_allowed_tools(
-                    matched.metadata.allowed_tools,
-                    preserved_names=_TASK_AGENT_PRESERVED_TOOL_NAMES,
-                )
-                set_allowed_tools = getattr(self._executor, "set_allowed_tools", None)
-                if callable(set_allowed_tools):
-                    set_allowed_tools(allowed_names, allowed_tags)
-                effective_registry = effective_registry.filter_by_names_or_tags(
-                    allowed_names, allowed_tags
-                )
-        else:
-            self._turn_unfiltered_registry = effective_registry
-
-        registry_fingerprint = effective_registry.anthropic_tools_fingerprint()
-        if (
-            self._shared_tools is not None
-            and self._shared_tools_fingerprint == registry_fingerprint
-        ):
-            tools = self._shared_tools
-        else:
-            tools = effective_registry.to_anthropic_tools(cache_breakpoint=cache_prompt)
+        )
+        prompt_assembly = activation.prompt_assembly
+        tools = self._tools_for_registry(activation, cache_prompt)
 
         while not state.completed and state.error is None:
             state = state.increment_iteration()
@@ -536,20 +395,35 @@ class TaskAgentRunner:
                 prompt_assembly.rendered,
             )
 
-            if self._pending_mid_turn_update is not None:
-                prompt_assembly, effective_registry, tools = (
-                    self._pending_mid_turn_update
+            update = self._pending_mid_turn_update
+            self._pending_mid_turn_update = None
+            if update is None:
+                update = await self._skill_controller.check_mid_turn_from_messages(
+                    list(state.messages),
+                    cache_prompt=cache_prompt,
                 )
-                self._pending_mid_turn_update = None
-
-            updated = await self._check_mid_turn_skill_activation(state)
-            if updated is not None:
-                prompt_assembly, effective_registry, tools = updated
+            if update is not None:
+                prompt_assembly = update.prompt_assembly
+                tools = self._tools_for_registry(update, cache_prompt)
 
         if state.error:
             raise RuntimeError(state.error)
 
         return extract_final_text(state)
+
+    def _tools_for_registry(
+        self,
+        activation: SkillActivation,
+        cache_prompt: bool,
+    ) -> list[dict[str, Any]]:
+        """Reuse the manager's shared tool payload when the registry matches."""
+        if (
+            self._shared_tools is not None
+            and self._shared_tools_fingerprint
+            == activation.registry.anthropic_tools_fingerprint()
+        ):
+            return self._shared_tools
+        return activation.tools
 
     async def _run_iteration(
         self,
@@ -561,23 +435,11 @@ class TaskAgentRunner:
     ) -> AgentState:
         """Run a single iteration of the task agent loop."""
         # Compact history before the LLM call if needed
-        if self._observer.should_compact(state.messages, system_prompt_text):
-            compacted = await self._observer.compact(
-                state.messages,
-                system_prompt_text,
-            )
-            self._context_compaction_count += 1
-            await self._emitter.emit(
-                EventType.CONTEXT_COMPACTED,
-                {
-                    "original_messages": len(state.messages),
-                    "compacted_messages": len(compacted),
-                    "summary_text": compaction_summary_for_persistence(compacted),
-                    "summary_scope": "task_agent",
-                    "agent_id": self._agent_id,
-                    "compaction_profile": self._compaction_profile.name,
-                },
-            )
+        compacted, did_compact = await self._compaction_step.maybe_compact(
+            state.messages,
+            system_prompt_text,
+        )
+        if did_compact:
             state = replace(state, messages=compacted)
 
         if state.iteration > self._max_iterations:
@@ -632,13 +494,14 @@ class TaskAgentRunner:
             return state.mark_completed()
 
         async def _post_tool_callback(tc: Any, result: Any) -> None:
-            skill_name = self._requested_skill_name_from_tool_call(tc.name, tc.input)
+            skill_name = self._skill_controller.requested_skill_name(tc.name, tc.input)
             if skill_name is None or not result.success:
                 return
-            updated = await self._apply_mid_turn_skill_activation(
+            updated = await self._skill_controller.apply_mid_turn(
                 skill_name,
                 tool_id=tc.id,
                 messages=list(state.messages),
+                cache_prompt=getattr(get_settings(), "PROMPT_CACHE_ENABLED", False),
             )
             if updated is not None:
                 self._pending_mid_turn_update = updated
@@ -679,58 +542,3 @@ class TaskAgentRunner:
             return state.mark_completed("Handing off to specialist agent.")
 
         return state
-
-    async def _check_mid_turn_skill_activation(
-        self,
-        state: AgentState,
-    ) -> tuple[PromptAssembly, ToolRegistry, list[dict[str, Any]]] | None:
-        """Detect successful mid-turn skill activation and apply constraints."""
-        if self._skill_registry is None:
-            return None
-
-        last_assistant = None
-        for msg in reversed(state.messages):
-            if msg.get("role") == "assistant":
-                last_assistant = msg
-                break
-
-        if last_assistant is None:
-            return None
-
-        content = last_assistant.get("content")
-        if not isinstance(content, list):
-            return None
-
-        activated_name: str | None = None
-        tool_id: str | None = None
-        for block in content:
-            if not isinstance(block, dict) or block.get("type") != "tool_use":
-                continue
-            block_name = block.get("name")
-            if block_name == "activate_skill":
-                skill_input = block.get("input", {})
-                activated_name = skill_input.get("name")
-                tool_id = block.get("id")
-                break
-            if (
-                isinstance(block_name, str)
-                and self._skill_registry.find_by_name(block_name) is not None
-            ):
-                activated_name = block_name
-                tool_id = block.get("id")
-                break
-
-        if not activated_name:
-            return None
-
-        if tool_id is not None and tool_use_had_error_result(
-            list(state.messages),
-            tool_id,
-        ):
-            return None
-
-        return await self._apply_mid_turn_skill_activation(
-            activated_name,
-            tool_id=tool_id,
-            messages=list(state.messages),
-        )

--- a/backend/tests/test_orchestrator_uploads.py
+++ b/backend/tests/test_orchestrator_uploads.py
@@ -513,10 +513,12 @@ async def test_run_iteration_uses_effective_prompt_for_compaction() -> None:
     )
     state = orchestrator._state.add_message({"role": "user", "content": "hello"})
 
-    result = await orchestrator._run_iteration(
+    result = await orchestrator._loop._run_iteration(
         state,
-        tools=[],
-        system_prompt="expanded prompt",
+        [],
+        "expanded prompt",
+        "expanded prompt",
+        False,
     )
 
     assert result.completed is True

--- a/backend/tests/test_planner.py
+++ b/backend/tests/test_planner.py
@@ -103,7 +103,11 @@ class TestPlannerCompaction:
     ):
         monkeypatch.setattr(
             "agent.runtime.planner.get_settings",
-            lambda: SimpleNamespace(LITE_MODEL="test-model"),
+            lambda: SimpleNamespace(
+                LITE_MODEL="test-model",
+                PLANNING_MODEL="test-model",
+                AGENT_DEBUG_LOGGING=False,
+            ),
         )
         observer = _RecordingObserver()
         profile = _planner_profile()
@@ -119,11 +123,12 @@ class TestPlannerCompaction:
         )
         state = AgentState(messages=({"role": "user", "content": "plan this"},))
 
-        result = await planner._run_iteration(
+        result = await planner._loop._run_iteration(
             state,
-            tools=[],
-            model="test-model",
-            system_prompt="expanded prompt",
+            [],
+            "expanded prompt",
+            "expanded prompt",
+            False,
         )
 
         assert result.completed is True
@@ -136,7 +141,11 @@ class TestPlannerCompaction:
     ):
         monkeypatch.setattr(
             "agent.runtime.planner.get_settings",
-            lambda: SimpleNamespace(LITE_MODEL="test-model"),
+            lambda: SimpleNamespace(
+                LITE_MODEL="test-model",
+                PLANNING_MODEL="test-model",
+                AGENT_DEBUG_LOGGING=False,
+            ),
         )
         events: list[str] = []
         profile = _planner_profile(memory_flush=True)
@@ -165,10 +174,12 @@ class TestPlannerCompaction:
             conversation_hooks=hooks,
         )
 
-        result = await planner._run_iteration(
+        result = await planner._loop._run_iteration(
             state,
-            tools=[],
-            model="test-model",
+            [],
+            "base prompt",
+            "base prompt",
+            False,
         )
 
         assert result.completed is True


### PR DESCRIPTION
The single-agent orchestrator, planner, and task-agent runner each
re-implemented the same skill-activation, context-compaction, and
turn-finalization logic. This collapses that triplicated machinery into
shared, single-sourced collaborators that all three loops compose.

- SkillActivationController (new): owns turn-start skill matching, mid-turn
  activate_skill handling, and tool/prompt restriction. Replaces three
  near-identical copies of _requested_skill_name_from_tool_call,
  _apply_mid_turn_skill_activation, and _check_mid_turn_skill_activation,
  parameterized only by install-context label and preserved tool names.
- CompactionStep (new): owns the observer-driven compaction sequence
  (should_compact -> hooks -> compact -> emit CONTEXT_COMPACTED). Web and
  planner wire in conversation hooks; the task runner uses the task_agent
  scope, agent_id, and a metrics callback.
- finalize_conversation_turn (helpers): shared cancel/error/complete
  finalization for the two conversation-style loops (web + planner).

Behavior is preserved: the full backend suite is unchanged at 1118 passed
with the same 4 pre-existing failures (2 prompt-cache, 2 search-provider
ordering). The three loop modules drop ~750 lines of duplication.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VH5PKCNmSYhfPJYeU8F3i6